### PR TITLE
USER-DPD workaround for neighbor list issues

### DIFF
--- a/src/USER-DPD/fix_shardlow.cpp
+++ b/src/USER-DPD/fix_shardlow.cpp
@@ -47,6 +47,7 @@
 #include "comm.h"
 #include "neighbor.h"
 #include "neigh_list.h"
+#include "neigh_request.h"
 #include "random_mars.h"
 #include "memory.h"
 #include "domain.h"
@@ -135,6 +136,23 @@ int FixShardlow::setmask()
   mask |= INITIAL_INTEGRATE;
   mask |= PRE_EXCHANGE | MIN_PRE_EXCHANGE;
   return mask;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixShardlow::init()
+{
+  int irequest = neighbor->request(this,instance_me);
+  neighbor->requests[irequest]->pair = 0;
+  neighbor->requests[irequest]->fix  = 1;
+  neighbor->requests[irequest]->ssa  = 1;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixShardlow::init_list(int id, NeighList *ptr)
+{
+  list = ptr;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -410,7 +428,6 @@ void FixShardlow::initial_integrate(int vflag)
   int nghost = atom->nghost;
 
   int airnum;
-  class NeighList *list; // points to list in pairDPD or pairDPDE
   class RanMars *pRNG;
 
   // NOTE: this logic is specific to orthogonal boxes, not triclinic
@@ -431,12 +448,10 @@ void FixShardlow::initial_integrate(int vflag)
   // Allocate memory for v_t0 to hold the initial velocities for the ghosts
   v_t0 = (double (*)[3]) memory->smalloc(sizeof(double)*3*nghost, "FixShardlow:v_t0");
 
-  // Define pointers to access the neighbor list and RNG
+  // Define pointers to access the RNG
   if(pairDPDE){
-    list = pairDPDE->list;
     pRNG = pairDPDE->random;
   } else {
-    list = pairDPD->list;
     pRNG = pairDPD->random;
   }
   inum = list->inum;

--- a/src/USER-DPD/fix_shardlow.h
+++ b/src/USER-DPD/fix_shardlow.h
@@ -26,9 +26,13 @@ namespace LAMMPS_NS {
 
 class FixShardlow : public Fix {
  public:
+  class NeighList *list; // The SSA specific neighbor list
+
   FixShardlow(class LAMMPS *, int, char **);
   ~FixShardlow();
   int setmask();
+  virtual void init();
+  virtual void init_list(int, class NeighList *);
   virtual void setup(int);
   virtual void initial_integrate(int);
   void setup_pre_exchange();

--- a/src/USER-DPD/pair_dpd_fdt.cpp
+++ b/src/USER-DPD/pair_dpd_fdt.cpp
@@ -320,11 +320,9 @@ void PairDPDfdt::init_style()
 
   splitFDT_flag = false;
   int irequest = neighbor->request(this,instance_me);
-  neighbor->requests[irequest]->ssa = 0;
   for (int i = 0; i < modify->nfix; i++)
     if (strcmp(modify->fix[i]->style,"shardlow") == 0){
       splitFDT_flag = true;
-      neighbor->requests[irequest]->ssa = 1;
     }
 }
 

--- a/src/USER-DPD/pair_dpd_fdt_energy.cpp
+++ b/src/USER-DPD/pair_dpd_fdt_energy.cpp
@@ -408,11 +408,9 @@ void PairDPDfdtEnergy::init_style()
 
   splitFDT_flag = false;
   int irequest = neighbor->request(this,instance_me);
-  neighbor->requests[irequest]->ssa = 0;
   for (int i = 0; i < modify->nfix; i++)
     if (strcmp(modify->fix[i]->style,"shardlow") == 0){
       splitFDT_flag = true;
-      neighbor->requests[irequest]->ssa = 1;
     }
 
   bool eos_flag = false;

--- a/src/neighbor.cpp
+++ b/src/neighbor.cpp
@@ -712,6 +712,7 @@ void Neighbor::init_pair()
     if (!requests[i]->fix && !requests[i]->compute) continue;
     for (j = 0; j < nrequest; j++) {
       if (lists[j] == NULL) continue;   // Kokkos
+      if (requests[i]->ssa != requests[j]->ssa) continue;
       if (requests[i]->half && requests[j]->pair && 
           !requests[j]->skip && requests[j]->half && !requests[j]->copy)
         break;


### PR DESCRIPTION
Stan,
This pull request is really just for you to look at to see if it resolves the problem for you that you reported when both USER-OMP and USER-DPD were enabled in the new-neighbor branch.
I've submitted it to Axel's new-neighbor branch as pull request 52 for him.

This forces fix_shardlow to request its own neighbor list that is SSA specific, and prevents that list from being copied, and thus misused by other parts of LAMMPS. Thus, USER-OMP and USER-DPD don't step on each other, as well as other things, such as pair_hybrid can't get confused either.