### PR TITLE
synchronization bugs in fix_momentum_kokkos

### DIFF
--- a/src/KOKKOS/fix_momentum_kokkos.cpp
+++ b/src/KOKKOS/fix_momentum_kokkos.cpp
@@ -181,6 +181,8 @@ void FixMomentumKokkos<DeviceType>::end_of_step()
     });
   }
 
+  atomKK->modified(execution_space, V_MASK);
+  // the following sync should not be needed once everything supports Kokkos
   atomKK->sync(ExecutionSpaceFromDevice<LMPHostType>::space, V_MASK);
 }
 


### PR DESCRIPTION
the sync() at the end wasn't needed, but many more were prior to calling Group methods.