### PR TITLE
fix a CUDA constructor warning

### DIFF
--- a/src/KOKKOS/Install.sh
+++ b/src/KOKKOS/Install.sh
@@ -143,7 +143,6 @@ action pair_eam_alloy_kokkos.h pair_eam_alloy.h
 action pair_eam_fs_kokkos.cpp pair_eam_fs.cpp
 action pair_eam_fs_kokkos.h pair_eam_fs.h
 action pair_kokkos.h
-action params_lj_coul.h
 action pair_lj_charmm_coul_charmm_implicit_kokkos.cpp pair_lj_charmm_coul_charmm_implicit.cpp
 action pair_lj_charmm_coul_charmm_implicit_kokkos.h pair_lj_charmm_coul_charmm_implicit.h
 action pair_lj_charmm_coul_charmm_kokkos.cpp pair_lj_charmm_coul_charmm.cpp

--- a/src/KOKKOS/Install.sh
+++ b/src/KOKKOS/Install.sh
@@ -143,6 +143,7 @@ action pair_eam_alloy_kokkos.h pair_eam_alloy.h
 action pair_eam_fs_kokkos.cpp pair_eam_fs.cpp
 action pair_eam_fs_kokkos.h pair_eam_fs.h
 action pair_kokkos.h
+action params_lj_coul.h
 action pair_lj_charmm_coul_charmm_implicit_kokkos.cpp pair_lj_charmm_coul_charmm_implicit.cpp
 action pair_lj_charmm_coul_charmm_implicit_kokkos.h pair_lj_charmm_coul_charmm_implicit.h
 action pair_lj_charmm_coul_charmm_kokkos.cpp pair_lj_charmm_coul_charmm.cpp

--- a/src/KOKKOS/kokkos_type.h
+++ b/src/KOKKOS/kokkos_type.h
@@ -915,6 +915,14 @@ void memset_kokkos (ViewType &view) {
   ViewType::execution_space::fence();
 }
 
+struct params_lj_coul {
+  KOKKOS_INLINE_FUNCTION
+  params_lj_coul(){cut_ljsq=0;cut_coulsq=0;lj1=0;lj2=0;lj3=0;lj4=0;offset=0;};   
+  KOKKOS_INLINE_FUNCTION
+  params_lj_coul(int i){cut_ljsq=0;cut_coulsq=0;lj1=0;lj2=0;lj3=0;lj4=0;offset=0;};
+  F_FLOAT cut_ljsq,cut_coulsq,lj1,lj2,lj3,lj4,offset;
+};
+
 #if defined(KOKKOS_HAVE_CXX11)
 #undef ISFINITE
 #define ISFINITE(x) std::isfinite(x)

--- a/src/KOKKOS/pair_lj_charmm_coul_charmm_implicit_kokkos.h
+++ b/src/KOKKOS/pair_lj_charmm_coul_charmm_implicit_kokkos.h
@@ -25,6 +25,7 @@ PairStyle(lj/charmm/coul/charmm/implicit/kk/host,PairLJCharmmCoulCharmmImplicitK
 #include "pair_kokkos.h"
 #include "pair_lj_charmm_coul_charmm_implicit.h"
 #include "neigh_list_kokkos.h"
+#include "params_lj_coul.h"
 
 namespace LAMMPS_NS {
 
@@ -44,11 +45,6 @@ class PairLJCharmmCoulCharmmImplicitKokkos : public PairLJCharmmCoulCharmmImplic
   void init_style();
   double init_one(int, int);
 
-  struct params_lj_coul{
-    params_lj_coul(){cut_ljsq=0;cut_coulsq=0;lj1=0;lj2=0;lj3=0;lj4=0;offset=0;};
-    params_lj_coul(int i){cut_ljsq=0;cut_coulsq=0;lj1=0;lj2=0;lj3=0;lj4=0;offset=0;};
-    F_FLOAT cut_ljsq,cut_coulsq,lj1,lj2,lj3,lj4,offset;
-  };
 
  protected:
   void cleanup_copy();

--- a/src/KOKKOS/pair_lj_charmm_coul_charmm_implicit_kokkos.h
+++ b/src/KOKKOS/pair_lj_charmm_coul_charmm_implicit_kokkos.h
@@ -25,7 +25,6 @@ PairStyle(lj/charmm/coul/charmm/implicit/kk/host,PairLJCharmmCoulCharmmImplicitK
 #include "pair_kokkos.h"
 #include "pair_lj_charmm_coul_charmm_implicit.h"
 #include "neigh_list_kokkos.h"
-#include "params_lj_coul.h"
 
 namespace LAMMPS_NS {
 

--- a/src/KOKKOS/pair_lj_charmm_coul_charmm_kokkos.h
+++ b/src/KOKKOS/pair_lj_charmm_coul_charmm_kokkos.h
@@ -25,6 +25,7 @@ PairStyle(lj/charmm/coul/charmm/kk/host,PairLJCharmmCoulCharmmKokkos<LMPHostType
 #include "pair_kokkos.h"
 #include "pair_lj_charmm_coul_charmm.h"
 #include "neigh_list_kokkos.h"
+#include "params_lj_coul.h"
 
 namespace LAMMPS_NS {
 
@@ -44,11 +45,6 @@ class PairLJCharmmCoulCharmmKokkos : public PairLJCharmmCoulCharmm {
   void init_style();
   double init_one(int, int);
 
-  struct params_lj_coul{
-    params_lj_coul(){cut_ljsq=0;cut_coulsq=0;lj1=0;lj2=0;lj3=0;lj4=0;offset=0;};
-    params_lj_coul(int i){cut_ljsq=0;cut_coulsq=0;lj1=0;lj2=0;lj3=0;lj4=0;offset=0;};
-    F_FLOAT cut_ljsq,cut_coulsq,lj1,lj2,lj3,lj4,offset;
-  };
 
  protected:
   void cleanup_copy();

--- a/src/KOKKOS/pair_lj_charmm_coul_charmm_kokkos.h
+++ b/src/KOKKOS/pair_lj_charmm_coul_charmm_kokkos.h
@@ -25,7 +25,6 @@ PairStyle(lj/charmm/coul/charmm/kk/host,PairLJCharmmCoulCharmmKokkos<LMPHostType
 #include "pair_kokkos.h"
 #include "pair_lj_charmm_coul_charmm.h"
 #include "neigh_list_kokkos.h"
-#include "params_lj_coul.h"
 
 namespace LAMMPS_NS {
 

--- a/src/KOKKOS/pair_lj_charmm_coul_long_kokkos.h
+++ b/src/KOKKOS/pair_lj_charmm_coul_long_kokkos.h
@@ -25,7 +25,6 @@ PairStyle(lj/charmm/coul/long/kk/host,PairLJCharmmCoulLongKokkos<LMPHostType>)
 #include "pair_kokkos.h"
 #include "pair_lj_charmm_coul_long.h"
 #include "neigh_list_kokkos.h"
-#include "params_lj_coul.h"
 
 namespace LAMMPS_NS {
 

--- a/src/KOKKOS/pair_lj_charmm_coul_long_kokkos.h
+++ b/src/KOKKOS/pair_lj_charmm_coul_long_kokkos.h
@@ -25,6 +25,7 @@ PairStyle(lj/charmm/coul/long/kk/host,PairLJCharmmCoulLongKokkos<LMPHostType>)
 #include "pair_kokkos.h"
 #include "pair_lj_charmm_coul_long.h"
 #include "neigh_list_kokkos.h"
+#include "params_lj_coul.h"
 
 namespace LAMMPS_NS {
 
@@ -42,12 +43,6 @@ class PairLJCharmmCoulLongKokkos : public PairLJCharmmCoulLong {
   void init_tables(double cut_coul, double *cut_respa);
   void init_style();
   double init_one(int, int);
-
-  struct params_lj_coul{
-    params_lj_coul(){cut_ljsq=0;cut_coulsq=0;lj1=0;lj2=0;lj3=0;lj4=0;offset=0;};
-    params_lj_coul(int i){cut_ljsq=0;cut_coulsq=0;lj1=0;lj2=0;lj3=0;lj4=0;offset=0;};
-    F_FLOAT cut_ljsq,cut_coulsq,lj1,lj2,lj3,lj4,offset;
-  };
 
  protected:
   void cleanup_copy();

--- a/src/KOKKOS/pair_lj_class2_coul_cut_kokkos.h
+++ b/src/KOKKOS/pair_lj_class2_coul_cut_kokkos.h
@@ -25,7 +25,6 @@ PairStyle(lj/class2/coul/cut/kk/host,PairLJClass2CoulCutKokkos<LMPHostType>)
 #include "pair_kokkos.h"
 #include "pair_lj_class2_coul_cut.h"
 #include "neigh_list_kokkos.h"
-#include "params_lj_coul.h"
 
 namespace LAMMPS_NS {
 

--- a/src/KOKKOS/pair_lj_class2_coul_cut_kokkos.h
+++ b/src/KOKKOS/pair_lj_class2_coul_cut_kokkos.h
@@ -25,6 +25,7 @@ PairStyle(lj/class2/coul/cut/kk/host,PairLJClass2CoulCutKokkos<LMPHostType>)
 #include "pair_kokkos.h"
 #include "pair_lj_class2_coul_cut.h"
 #include "neigh_list_kokkos.h"
+#include "params_lj_coul.h"
 
 namespace LAMMPS_NS {
 
@@ -43,11 +44,6 @@ class PairLJClass2CoulCutKokkos : public PairLJClass2CoulCut {
   void init_style();
   double init_one(int, int);
 
-  struct params_lj_coul{
-    params_lj_coul(){cut_ljsq=0;cut_coulsq=0;lj1=0;lj2=0;lj3=0;lj4=0;offset=0;};
-    params_lj_coul(int i){cut_ljsq=0;cut_coulsq=0;lj1=0;lj2=0;lj3=0;lj4=0;offset=0;};
-    F_FLOAT cut_ljsq,cut_coulsq,lj1,lj2,lj3,lj4,offset;
-  };
 
  protected:
   void cleanup_copy();

--- a/src/KOKKOS/pair_lj_class2_coul_long_kokkos.h
+++ b/src/KOKKOS/pair_lj_class2_coul_long_kokkos.h
@@ -25,7 +25,6 @@ PairStyle(lj/class2/coul/long/kk/host,PairLJClass2CoulLongKokkos<LMPHostType>)
 #include "pair_kokkos.h"
 #include "pair_lj_class2_coul_long.h"
 #include "neigh_list_kokkos.h"
-#include "params_lj_coul.h"
 
 namespace LAMMPS_NS {
 

--- a/src/KOKKOS/pair_lj_class2_coul_long_kokkos.h
+++ b/src/KOKKOS/pair_lj_class2_coul_long_kokkos.h
@@ -25,6 +25,7 @@ PairStyle(lj/class2/coul/long/kk/host,PairLJClass2CoulLongKokkos<LMPHostType>)
 #include "pair_kokkos.h"
 #include "pair_lj_class2_coul_long.h"
 #include "neigh_list_kokkos.h"
+#include "params_lj_coul.h"
 
 namespace LAMMPS_NS {
 
@@ -43,12 +44,6 @@ class PairLJClass2CoulLongKokkos : public PairLJClass2CoulLong {
   void init_tables(double cut_coul, double *cut_respa);
   void init_style();
   double init_one(int, int);
-
-  struct params_lj_coul{
-    params_lj_coul(){cut_ljsq=0;cut_coulsq=0;lj1=0;lj2=0;lj3=0;lj4=0;offset=0;};
-    params_lj_coul(int i){cut_ljsq=0;cut_coulsq=0;lj1=0;lj2=0;lj3=0;lj4=0;offset=0;};
-    F_FLOAT cut_ljsq,cut_coulsq,lj1,lj2,lj3,lj4,offset;
-  };
 
  protected:
   void cleanup_copy();

--- a/src/KOKKOS/pair_lj_cut_coul_cut_kokkos.h
+++ b/src/KOKKOS/pair_lj_cut_coul_cut_kokkos.h
@@ -25,6 +25,7 @@ PairStyle(lj/cut/coul/cut/kk/host,PairLJCutCoulCutKokkos<LMPHostType>)
 #include "pair_kokkos.h"
 #include "pair_lj_cut_coul_cut.h"
 #include "neigh_list_kokkos.h"
+#include "params_lj_coul.h"
 
 namespace LAMMPS_NS {
 
@@ -42,14 +43,6 @@ class PairLJCutCoulCutKokkos : public PairLJCutCoulCut {
   void settings(int, char **);
   void init_style();
   double init_one(int, int);
-
-  struct params_lj_coul{
-    KOKKOS_INLINE_FUNCTION
-    params_lj_coul(){cut_ljsq=0;cut_coulsq=0;lj1=0;lj2=0;lj3=0;lj4=0;offset=0;};
-    KOKKOS_INLINE_FUNCTION
-    params_lj_coul(int i){cut_ljsq=0;cut_coulsq=0;lj1=0;lj2=0;lj3=0;lj4=0;offset=0;};
-    F_FLOAT cut_ljsq,cut_coulsq,lj1,lj2,lj3,lj4,offset;
-  };
 
  protected:
   void cleanup_copy();

--- a/src/KOKKOS/pair_lj_cut_coul_cut_kokkos.h
+++ b/src/KOKKOS/pair_lj_cut_coul_cut_kokkos.h
@@ -25,7 +25,6 @@ PairStyle(lj/cut/coul/cut/kk/host,PairLJCutCoulCutKokkos<LMPHostType>)
 #include "pair_kokkos.h"
 #include "pair_lj_cut_coul_cut.h"
 #include "neigh_list_kokkos.h"
-#include "params_lj_coul.h"
 
 namespace LAMMPS_NS {
 

--- a/src/KOKKOS/pair_lj_cut_coul_debye_kokkos.h
+++ b/src/KOKKOS/pair_lj_cut_coul_debye_kokkos.h
@@ -25,7 +25,6 @@ PairStyle(lj/cut/coul/debye/kk/host,PairLJCutCoulDebyeKokkos<LMPHostType>)
 #include "pair_kokkos.h"
 #include "pair_lj_cut_coul_debye.h"
 #include "neigh_list_kokkos.h"
-#include "params_lj_coul.h"
 
 namespace LAMMPS_NS {
 

--- a/src/KOKKOS/pair_lj_cut_coul_debye_kokkos.h
+++ b/src/KOKKOS/pair_lj_cut_coul_debye_kokkos.h
@@ -25,6 +25,7 @@ PairStyle(lj/cut/coul/debye/kk/host,PairLJCutCoulDebyeKokkos<LMPHostType>)
 #include "pair_kokkos.h"
 #include "pair_lj_cut_coul_debye.h"
 #include "neigh_list_kokkos.h"
+#include "params_lj_coul.h"
 
 namespace LAMMPS_NS {
 
@@ -42,12 +43,6 @@ class PairLJCutCoulDebyeKokkos : public PairLJCutCoulDebye {
   void settings(int, char **);
   void init_style();
   double init_one(int, int);
-
-  struct params_lj_coul{
-    params_lj_coul(){cut_ljsq=0;cut_coulsq=0;lj1=0;lj2=0;lj3=0;lj4=0;offset=0;};
-    params_lj_coul(int i){cut_ljsq=0;cut_coulsq=0;lj1=0;lj2=0;lj3=0;lj4=0;offset=0;};
-    F_FLOAT cut_ljsq,cut_coulsq,lj1,lj2,lj3,lj4,offset;
-  };
 
  protected:
   void cleanup_copy();

--- a/src/KOKKOS/pair_lj_cut_coul_dsf_kokkos.h
+++ b/src/KOKKOS/pair_lj_cut_coul_dsf_kokkos.h
@@ -25,7 +25,6 @@ PairStyle(lj/cut/coul/dsf/kk/host,PairLJCutCoulDSFKokkos<LMPHostType>)
 #include "pair_kokkos.h"
 #include "pair_lj_cut_coul_dsf.h"
 #include "neigh_list_kokkos.h"
-#include "params_lj_coul.h"
 
 namespace LAMMPS_NS {
 

--- a/src/KOKKOS/pair_lj_cut_coul_dsf_kokkos.h
+++ b/src/KOKKOS/pair_lj_cut_coul_dsf_kokkos.h
@@ -25,6 +25,7 @@ PairStyle(lj/cut/coul/dsf/kk/host,PairLJCutCoulDSFKokkos<LMPHostType>)
 #include "pair_kokkos.h"
 #include "pair_lj_cut_coul_dsf.h"
 #include "neigh_list_kokkos.h"
+#include "params_lj_coul.h"
 
 namespace LAMMPS_NS {
 
@@ -41,12 +42,6 @@ class PairLJCutCoulDSFKokkos : public PairLJCutCoulDSF {
 
   void init_style();
   double init_one(int, int);
-
-  struct params_lj_coul{
-    params_lj_coul(){cut_ljsq=0;cut_coulsq=0;lj1=0;lj2=0;lj3=0;lj4=0;offset=0;};
-    params_lj_coul(int i){cut_ljsq=0;cut_coulsq=0;lj1=0;lj2=0;lj3=0;lj4=0;offset=0;};
-    F_FLOAT cut_ljsq,cut_coulsq,lj1,lj2,lj3,lj4,offset;
-  };
 
  protected:
   void cleanup_copy();

--- a/src/KOKKOS/pair_lj_cut_coul_long_kokkos.h
+++ b/src/KOKKOS/pair_lj_cut_coul_long_kokkos.h
@@ -25,7 +25,6 @@ PairStyle(lj/cut/coul/long/kk/host,PairLJCutCoulLongKokkos<LMPHostType>)
 #include "pair_kokkos.h"
 #include "pair_lj_cut_coul_long.h"
 #include "neigh_list_kokkos.h"
-#include "params_lj_coul.h"
 
 namespace LAMMPS_NS {
 

--- a/src/KOKKOS/pair_lj_cut_coul_long_kokkos.h
+++ b/src/KOKKOS/pair_lj_cut_coul_long_kokkos.h
@@ -25,6 +25,7 @@ PairStyle(lj/cut/coul/long/kk/host,PairLJCutCoulLongKokkos<LMPHostType>)
 #include "pair_kokkos.h"
 #include "pair_lj_cut_coul_long.h"
 #include "neigh_list_kokkos.h"
+#include "params_lj_coul.h"
 
 namespace LAMMPS_NS {
 
@@ -43,12 +44,6 @@ class PairLJCutCoulLongKokkos : public PairLJCutCoulLong {
   void init_tables(double cut_coul, double *cut_respa);
   void init_style();
   double init_one(int, int);
-
-  struct params_lj_coul{
-    params_lj_coul(){cut_ljsq=0;cut_coulsq=0;lj1=0;lj2=0;lj3=0;lj4=0;offset=0;};
-    params_lj_coul(int i){cut_ljsq=0;cut_coulsq=0;lj1=0;lj2=0;lj3=0;lj4=0;offset=0;};
-    F_FLOAT cut_ljsq,cut_coulsq,lj1,lj2,lj3,lj4,offset;
-  };
 
  protected:
   void cleanup_copy();

--- a/src/KOKKOS/pair_lj_gromacs_coul_gromacs_kokkos.cpp
+++ b/src/KOKKOS/pair_lj_gromacs_coul_gromacs_kokkos.cpp
@@ -286,7 +286,7 @@ void PairLJGromacsCoulGromacsKokkos<DeviceType>::allocate()
   memory->create_kokkos(k_cut_coulsq,n+1,n+1,"pair:cut_coulsq");
   d_cut_coulsq = k_cut_coulsq.template view<DeviceType>();
 
-  k_params = Kokkos::DualView<params_lj_coul**,Kokkos::LayoutRight,DeviceType>("PairLJGromacsCoulGromacs::params",n+1,n+1);
+  k_params = Kokkos::DualView<params_lj_coul_gromacs**,Kokkos::LayoutRight,DeviceType>("PairLJGromacsCoulGromacs::params",n+1,n+1);
   params = k_params.d_view;
 }
 

--- a/src/KOKKOS/pair_lj_gromacs_coul_gromacs_kokkos.h
+++ b/src/KOKKOS/pair_lj_gromacs_coul_gromacs_kokkos.h
@@ -44,11 +44,11 @@ class PairLJGromacsCoulGromacsKokkos : public PairLJGromacsCoulGromacs {
   void init_style();
   double init_one(int, int);
 
-  struct params_lj_coul{
+  struct params_lj_coul_gromacs{
     KOKKOS_INLINE_FUNCTION
-    params_lj_coul(){cut_ljsq=0;cut_coulsq=0;lj1=0;lj2=0;lj3=0;lj4=0;offset=0;ljsw1=0;ljsw2=0;ljsw3=0;ljsw4=0;ljsw5=0;};
+    params_lj_coul_gromacs(){cut_ljsq=0;cut_coulsq=0;lj1=0;lj2=0;lj3=0;lj4=0;offset=0;ljsw1=0;ljsw2=0;ljsw3=0;ljsw4=0;ljsw5=0;};
     KOKKOS_INLINE_FUNCTION
-    params_lj_coul(int i){cut_ljsq=0;cut_coulsq=0;lj1=0;lj2=0;lj3=0;lj4=0;offset=0;ljsw1=0;ljsw2=0;ljsw3=0;ljsw4=0;ljsw5=0;};
+    params_lj_coul_gromacs(int i){cut_ljsq=0;cut_coulsq=0;lj1=0;lj2=0;lj3=0;lj4=0;offset=0;ljsw1=0;ljsw2=0;ljsw3=0;ljsw4=0;ljsw5=0;};
     F_FLOAT cut_ljsq,cut_coulsq,lj1,lj2,lj3,lj4,offset,ljsw1,ljsw2,ljsw3,ljsw4,ljsw5;
   };
 
@@ -75,11 +75,11 @@ class PairLJGromacsCoulGromacsKokkos : public PairLJGromacsCoulGromacs {
   F_FLOAT compute_ecoul(const F_FLOAT& rsq, const int& i, const int&j,
                         const int& itype, const int& jtype, const F_FLOAT& factor_coul, const F_FLOAT& qtmp) const;
 
-  Kokkos::DualView<params_lj_coul**,Kokkos::LayoutRight,DeviceType> k_params;
-  typename Kokkos::DualView<params_lj_coul**,
+  Kokkos::DualView<params_lj_coul_gromacs**,Kokkos::LayoutRight,DeviceType> k_params;
+  typename Kokkos::DualView<params_lj_coul_gromacs**,
     Kokkos::LayoutRight,DeviceType>::t_dev_const_um params;
   // hardwired to space for 12 atom types
-  params_lj_coul m_params[MAX_TYPES_STACKPARAMS+1][MAX_TYPES_STACKPARAMS+1];
+  params_lj_coul_gromacs m_params[MAX_TYPES_STACKPARAMS+1][MAX_TYPES_STACKPARAMS+1];
 
   F_FLOAT m_cutsq[MAX_TYPES_STACKPARAMS+1][MAX_TYPES_STACKPARAMS+1];
   F_FLOAT m_cut_ljsq[MAX_TYPES_STACKPARAMS+1][MAX_TYPES_STACKPARAMS+1];

--- a/src/KOKKOS/pair_lj_gromacs_coul_gromacs_kokkos.h
+++ b/src/KOKKOS/pair_lj_gromacs_coul_gromacs_kokkos.h
@@ -45,7 +45,9 @@ class PairLJGromacsCoulGromacsKokkos : public PairLJGromacsCoulGromacs {
   double init_one(int, int);
 
   struct params_lj_coul{
+    KOKKOS_INLINE_FUNCTION
     params_lj_coul(){cut_ljsq=0;cut_coulsq=0;lj1=0;lj2=0;lj3=0;lj4=0;offset=0;ljsw1=0;ljsw2=0;ljsw3=0;ljsw4=0;ljsw5=0;};
+    KOKKOS_INLINE_FUNCTION
     params_lj_coul(int i){cut_ljsq=0;cut_coulsq=0;lj1=0;lj2=0;lj3=0;lj4=0;offset=0;ljsw1=0;ljsw2=0;ljsw3=0;ljsw4=0;ljsw5=0;};
     F_FLOAT cut_ljsq,cut_coulsq,lj1,lj2,lj3,lj4,offset,ljsw1,ljsw2,ljsw3,ljsw4,ljsw5;
   };


### PR DESCRIPTION
The class params_lj_coul was copy-pasted
into many different pair styles, and only
one of them had the proper KOKKOS_INLINE_FUNCTION
annotations for CUDA.
created a header file for this class that
most of the pair styles now include.
One pair style did add extra members,
so it keeps a local copy of the class.

@stanmoore1 