### PR TITLE
Patched ff

### DIFF
--- a/src/KOKKOS/fix_qeq_reaxff_kokkos.cpp
+++ b/src/KOKKOS/fix_qeq_reaxff_kokkos.cpp
@@ -802,6 +802,7 @@ template<class DeviceType>
 int FixQEqReaxFFKokkos<DeviceType>::cg_solve1()
 // b = b_s, x = s;
 {
+  int loop;
 #ifndef HIP_OPT_CG_SOLVE_FUSED
   const int inum = list->inum;
   F_FLOAT tmp, sig_old, b_norm;
@@ -873,7 +874,6 @@ int FixQEqReaxFFKokkos<DeviceType>::cg_solve1()
   MPI_Allreduce(&my_dot, &dot_sqr, 1, MPI_DOUBLE, MPI_SUM, world);
   F_FLOAT sig_new = dot_sqr;
 
-  int loop;
   for (loop = 1; (loop < imax) && (sqrt(sig_new)/b_norm > tolerance); loop++) {
 
     // comm->forward_comm_fix(this); //Dist_vector(d);
@@ -947,8 +947,8 @@ int FixQEqReaxFFKokkos<DeviceType>::cg_solve1()
                                      "failed after {} iterations at step {}: "
                                      "{}", loop, update->ntimestep,
                                      sqrt(sig_new)/b_norm));
-  return loop;
 #endif
+  return loop;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -957,6 +957,7 @@ template<class DeviceType>
 int FixQEqReaxFFKokkos<DeviceType>::cg_solve2()
 // b = b_t, x = t;
 {
+  int loop;
 #ifndef HIP_OPT_CG_SOLVE_FUSED
   const int inum = list->inum;
   F_FLOAT tmp, sig_old, b_norm;
@@ -1029,7 +1030,6 @@ int FixQEqReaxFFKokkos<DeviceType>::cg_solve2()
   MPI_Allreduce(&my_dot, &dot_sqr, 1, MPI_DOUBLE, MPI_SUM, world);
   F_FLOAT sig_new = dot_sqr;
 
-  int loop;
   for (loop = 1; (loop < imax) && (sqrt(sig_new)/b_norm > tolerance); loop++) {
 
     // comm->forward_comm_fix(this); //Dist_vector(d);
@@ -1103,8 +1103,8 @@ int FixQEqReaxFFKokkos<DeviceType>::cg_solve2()
                                      "failed after {} iterations at step {}: "
                                      "{}", loop, update->ntimestep,
                                      sqrt(sig_new)/b_norm));
-  return loop;
 #endif
+  return loop;
 }
 
 #ifdef HIP_OPT_CG_SOLVE_FUSED

--- a/src/KOKKOS/fix_qeq_reaxff_kokkos.cpp
+++ b/src/KOKKOS/fix_qeq_reaxff_kokkos.cpp
@@ -415,9 +415,10 @@ void FixQEqReaxFFKokkos<DeviceType>::allocate_array()
     d_d = k_d.template view<DeviceType>();
     h_d = k_d.h_view;
 
+#endif
+
     memoryKK->create_kokkos(k_chi_field,chi_field,nmax,"qeq/kk:chi_field");
     d_chi_field = k_chi_field.template view<DeviceType>();
-#endif
 
 #ifdef HIP_OPT_CG_SOLVE_FUSED
     k_o_fused = DAT::tdual_ffloat2_1d("qeq/kk:o",nmax);

--- a/src/KOKKOS/fix_qeq_reaxff_kokkos.h
+++ b/src/KOKKOS/fix_qeq_reaxff_kokkos.h
@@ -318,10 +318,10 @@ class FixQEqReaxFFKokkos : public FixQEqReaxFF, public KokkosBase {
   void init_hist();
   void allocate_matrix();
   void allocate_array();
-  void cg_solve1();
-  void cg_solve2();
+  int cg_solve1();
+  int cg_solve2();
   #ifdef HIP_OPT_CG_SOLVE_FUSED
-  void cg_solve_fused();
+  int cg_solve_fused();
   #endif
   void calculate_q();
 
@@ -471,10 +471,10 @@ struct FixQEqReaxFFKokkosSparse22Functor  {
 
 #ifdef HIP_OPT_CG_SOLVE_FUSED
 template <class DeviceType>
-struct FixQEqReaxKokkosSparse22FusedFunctor  {
+struct FixQEqReaxFFKokkosSparse22FusedFunctor  {
   typedef DeviceType  device_type ;
-  FixQEqReaxKokkos<DeviceType> c;
-  FixQEqReaxKokkosSparse22FusedFunctor(FixQEqReaxKokkos<DeviceType>* c_ptr):c(*c_ptr) {
+  FixQEqReaxFFKokkos<DeviceType> c;
+  FixQEqReaxFFKokkosSparse22FusedFunctor(FixQEqReaxFFKokkos<DeviceType>* c_ptr):c(*c_ptr) {
     c.cleanup_copy();
   };
   KOKKOS_INLINE_FUNCTION
@@ -512,10 +512,10 @@ struct FixQEqReaxFFKokkosSparse32Functor  {
 
 #ifdef HIP_OPT_CG_SOLVE_FUSED
 template <class DeviceType>
-struct FixQEqReaxKokkosSparse12_32Functor  {
+struct FixQEqReaxFFKokkosSparse12_32Functor  {
   typedef DeviceType  device_type ;
-  FixQEqReaxKokkos<DeviceType> c;
-  FixQEqReaxKokkosSparse12_32Functor(FixQEqReaxKokkos<DeviceType>* c_ptr):c(*c_ptr) {
+  FixQEqReaxFFKokkos<DeviceType> c;
+  FixQEqReaxFFKokkosSparse12_32Functor(FixQEqReaxFFKokkos<DeviceType>* c_ptr):c(*c_ptr) {
     c.cleanup_copy();
   };
   KOKKOS_INLINE_FUNCTION
@@ -553,10 +553,10 @@ struct FixQEqReaxFFKokkosVecSum2Functor  {
 
 #ifdef HIP_OPT_CG_SOLVE_FUSED
 template <class DeviceType>
-struct FixQEqReaxKokkosVecSum2FusedFunctor  {
+struct FixQEqReaxFFKokkosVecSum2FusedFunctor  {
   typedef DeviceType  device_type ;
-  FixQEqReaxKokkos<DeviceType> c;
-  FixQEqReaxKokkosVecSum2FusedFunctor(FixQEqReaxKokkos<DeviceType>* c_ptr):c(*c_ptr) {
+  FixQEqReaxFFKokkos<DeviceType> c;
+  FixQEqReaxFFKokkosVecSum2FusedFunctor(FixQEqReaxFFKokkos<DeviceType>* c_ptr):c(*c_ptr) {
     c.cleanup_copy();
   };
   KOKKOS_INLINE_FUNCTION
@@ -597,11 +597,11 @@ struct FixQEqReaxFFKokkosNorm2Functor  {
 #ifdef HIP_OPT_CG_SOLVE_FUSED
 // fused operator
 template <class DeviceType>
-struct FixQEqReaxKokkosNorm12Functor  {
+struct FixQEqReaxFFKokkosNorm12Functor  {
   typedef DeviceType  device_type ;
-  FixQEqReaxKokkos<DeviceType> c;
+  FixQEqReaxFFKokkos<DeviceType> c;
   typedef F_FLOAT2 value_type;
-  FixQEqReaxKokkosNorm12Functor(FixQEqReaxKokkos<DeviceType>* c_ptr):c(*c_ptr) {
+  FixQEqReaxFFKokkosNorm12Functor(FixQEqReaxFFKokkos<DeviceType>* c_ptr):c(*c_ptr) {
     c.cleanup_copy();
   };
   KOKKOS_INLINE_FUNCTION
@@ -642,11 +642,11 @@ struct FixQEqReaxFFKokkosDot2Functor  {
 #ifdef HIP_OPT_CG_SOLVE_FUSED
 // fused operators
 template <class DeviceType>
-struct FixQEqReaxKokkosDot11Functor  {
+struct FixQEqReaxFFKokkosDot11Functor  {
   typedef DeviceType  device_type ;
-  FixQEqReaxKokkos<DeviceType> c;
+  FixQEqReaxFFKokkos<DeviceType> c;
   typedef F_FLOAT2 value_type;
-  FixQEqReaxKokkosDot11Functor(FixQEqReaxKokkos<DeviceType>* c_ptr):c(*c_ptr) {
+  FixQEqReaxFFKokkosDot11Functor(FixQEqReaxFFKokkos<DeviceType>* c_ptr):c(*c_ptr) {
     c.cleanup_copy();
   };
   KOKKOS_INLINE_FUNCTION
@@ -656,11 +656,11 @@ struct FixQEqReaxKokkosDot11Functor  {
 };
 
 template <class DeviceType>
-struct FixQEqReaxKokkosDot22Functor  {
+struct FixQEqReaxFFKokkosDot22Functor  {
   typedef DeviceType  device_type ;
-  FixQEqReaxKokkos<DeviceType> c;
+  FixQEqReaxFFKokkos<DeviceType> c;
   typedef F_FLOAT2 value_type;
-  FixQEqReaxKokkosDot22Functor(FixQEqReaxKokkos<DeviceType>* c_ptr):c(*c_ptr) {
+  FixQEqReaxFFKokkosDot22Functor(FixQEqReaxFFKokkos<DeviceType>* c_ptr):c(*c_ptr) {
     c.cleanup_copy();
   };
   KOKKOS_INLINE_FUNCTION
@@ -698,10 +698,10 @@ struct FixQEqReaxFFKokkosPrecon2Functor  {
 
 #ifdef HIP_OPT_CG_SOLVE_FUSED
 template <class DeviceType>
-struct FixQEqReaxKokkosPrecon12Functor  {
+struct FixQEqReaxFFKokkosPrecon12Functor  {
   typedef DeviceType  device_type ;
-  FixQEqReaxKokkos<DeviceType> c;
-  FixQEqReaxKokkosPrecon12Functor(FixQEqReaxKokkos<DeviceType>* c_ptr):c(*c_ptr) {
+  FixQEqReaxFFKokkos<DeviceType> c;
+  FixQEqReaxFFKokkosPrecon12Functor(FixQEqReaxFFKokkos<DeviceType>* c_ptr):c(*c_ptr) {
     c.cleanup_copy();
   };
   KOKKOS_INLINE_FUNCTION
@@ -727,11 +727,11 @@ struct FixQEqReaxFFKokkosPreconFunctor  {
 
 #ifdef HIP_OPT_CG_SOLVE_FUSED
 template <class DeviceType>
-struct FixQEqReaxKokkosPreconFusedFunctor  {
+struct FixQEqReaxFFKokkosPreconFusedFunctor  {
   typedef DeviceType  device_type ;
-  FixQEqReaxKokkos<DeviceType> c;
+  FixQEqReaxFFKokkos<DeviceType> c;
   typedef F_FLOAT2 value_type;
-  FixQEqReaxKokkosPreconFusedFunctor(FixQEqReaxKokkos<DeviceType>* c_ptr):c(*c_ptr) {
+  FixQEqReaxFFKokkosPreconFusedFunctor(FixQEqReaxFFKokkos<DeviceType>* c_ptr):c(*c_ptr) {
     c.cleanup_copy();
   };
   KOKKOS_INLINE_FUNCTION

--- a/src/KOKKOS/fix_qeq_reaxff_kokkos.h
+++ b/src/KOKKOS/fix_qeq_reaxff_kokkos.h
@@ -38,8 +38,13 @@ struct TagSparseMatvec1 {};
 struct TagSparseMatvec1Vector {};
 struct TagSparseMatvec2 {};
 struct TagSparseMatvec2Vector {};
+struct TagSparseMatvec2Fused {};
+struct TagSparseMatvec2FusedVector {};
 struct TagSparseMatvec3 {};
 struct TagSparseMatvec3Vector {};
+// fused operators
+struct TagSparseMatvec13 {};
+struct TagSparseMatvec13Vector {};
 struct TagZeroQGhosts{};
 struct TagFixQEqReaxFFPackForwardComm {};
 struct TagFixQEqReaxFFUnpackForwardComm {};
@@ -84,12 +89,22 @@ class FixQEqReaxFFKokkos : public FixQEqReaxFF, public KokkosBase {
   KOKKOS_INLINE_FUNCTION
   void sparse22_item(int) const;
 
+  #ifdef HIP_OPT_CG_SOLVE_FUSED
+  KOKKOS_INLINE_FUNCTION
+  void sparse22_fused_item(int) const;
+  #endif
+
   template<int NEIGHFLAG>
   KOKKOS_INLINE_FUNCTION
   void sparse23_item(int) const;
 
   KOKKOS_INLINE_FUNCTION
   void sparse32_item(int) const;
+
+  #ifdef HIP_OPT_CG_SOLVE_FUSED
+  KOKKOS_INLINE_FUNCTION
+  void sparse12_32_item(int) const;
+  #endif
 
   template<int NEIGHFLAG>
   KOKKOS_INLINE_FUNCTION
@@ -111,6 +126,16 @@ class FixQEqReaxFFKokkos : public FixQEqReaxFF, public KokkosBase {
   KOKKOS_INLINE_FUNCTION
   void operator() (TagSparseMatvec2Vector, const membertype2vec &team) const;
 
+  typedef typename Kokkos::TeamPolicy <DeviceType, TagSparseMatvec2Fused> ::member_type membertype2fused;
+  KOKKOS_INLINE_FUNCTION
+  void operator() (TagSparseMatvec2Fused, const membertype2fused &team) const;
+
+#ifdef HIP_OPT_CG_SOLVE_FUSED
+  typedef typename Kokkos::TeamPolicy <DeviceType, TagSparseMatvec2FusedVector> ::member_type membertype2fusedvec;
+  KOKKOS_INLINE_FUNCTION
+  void operator() (TagSparseMatvec2FusedVector, const membertype2fusedvec &team) const;
+#endif
+
   typedef typename Kokkos::TeamPolicy <DeviceType, TagSparseMatvec3> ::member_type membertype3;
   KOKKOS_INLINE_FUNCTION
   void operator() (TagSparseMatvec3, const membertype3 &team) const;
@@ -119,11 +144,26 @@ class FixQEqReaxFFKokkos : public FixQEqReaxFF, public KokkosBase {
   KOKKOS_INLINE_FUNCTION
   void operator() (TagSparseMatvec3Vector, const membertype3vec &team) const;
 
+#ifdef HIP_OPT_CG_SOLVE_FUSED
+  typedef typename Kokkos::TeamPolicy <DeviceType, TagSparseMatvec13> ::member_type membertype13;
+  KOKKOS_INLINE_FUNCTION
+  void operator() (TagSparseMatvec13, const membertype13 &team) const;
+
+  typedef typename Kokkos::TeamPolicy <DeviceType, TagSparseMatvec13Vector> ::member_type membertype13vec;
+  KOKKOS_INLINE_FUNCTION
+  void operator() (TagSparseMatvec13Vector, const membertype13vec &team) const;
+#endif
+
   KOKKOS_INLINE_FUNCTION
   void operator()(TagZeroQGhosts, const int&) const;
 
   KOKKOS_INLINE_FUNCTION
   void vecsum2_item(int) const;
+
+#ifdef HIP_OPT_CG_SOLVE_FUSED
+  KOKKOS_INLINE_FUNCTION
+  void vecsum2_fused_item(int) const;
+#endif
 
   KOKKOS_INLINE_FUNCTION
   double norm1_item(int) const;
@@ -131,11 +171,26 @@ class FixQEqReaxFFKokkos : public FixQEqReaxFF, public KokkosBase {
   KOKKOS_INLINE_FUNCTION
   double norm2_item(int) const;
 
+#ifdef HIP_OPT_CG_SOLVE_FUSED
+  // fused operator
+  KOKKOS_INLINE_FUNCTION
+  void norm12_item(int, F_FLOAT2&) const;
+#endif
+
   KOKKOS_INLINE_FUNCTION
   double dot1_item(int) const;
 
   KOKKOS_INLINE_FUNCTION
   double dot2_item(int) const;
+
+#ifdef HIP_OPT_CG_SOLVE_FUSED
+  // fused operators
+  KOKKOS_INLINE_FUNCTION
+  void dot11_item(int, F_FLOAT2&) const;
+
+  KOKKOS_INLINE_FUNCTION
+  void dot22_item(int, F_FLOAT2&) const;
+#endif
 
   KOKKOS_INLINE_FUNCTION
   void precon1_item(int) const;
@@ -143,8 +198,19 @@ class FixQEqReaxFFKokkos : public FixQEqReaxFF, public KokkosBase {
   KOKKOS_INLINE_FUNCTION
   void precon2_item(int) const;
 
+#ifdef HIP_OPT_CG_SOLVE_FUSED
+  // fused operator
+  KOKKOS_INLINE_FUNCTION
+  void precon12_item(int) const;
+#endif
+
   KOKKOS_INLINE_FUNCTION
   double precon_item(int) const;
+
+#ifdef HIP_OPT_CG_SOLVE_FUSED
+  KOKKOS_INLINE_FUNCTION
+  void precon_fused_item(int, F_FLOAT2&) const;
+#endif
 
   KOKKOS_INLINE_FUNCTION
   double vecacc1_item(int) const;
@@ -224,6 +290,15 @@ class FixQEqReaxFFKokkos : public FixQEqReaxFF, public KokkosBase {
   DAT::tdual_ffloat_1d k_o, k_d;
   typename AT::t_ffloat_1d d_p, d_o, d_r, d_d;
   HAT::t_ffloat_1d h_o, h_d;
+
+#ifdef HIP_OPT_CG_SOLVE_FUSED
+  // fused arrays
+  DAT::tdual_ffloat2_1d k_o_fused, k_d_fused;
+  typename AT::t_ffloat2_1d d_p_fused, d_o_fused, d_r_fused, d_d_fused;
+  HAT::t_ffloat2_1d h_o_fused, h_d_fused;
+  int converged = 0;
+#endif
+
   typename AT::t_ffloat_1d_randomread r_p, r_o, r_r, r_d;
 
   DAT::tdual_ffloat_2d k_shield, k_s_hist, k_t_hist;
@@ -243,14 +318,23 @@ class FixQEqReaxFFKokkos : public FixQEqReaxFF, public KokkosBase {
   void init_hist();
   void allocate_matrix();
   void allocate_array();
-  int cg_solve1();
-  int cg_solve2();
+  void cg_solve1();
+  void cg_solve2();
+  #ifdef HIP_OPT_CG_SOLVE_FUSED
+  void cg_solve_fused();
+  #endif
   void calculate_q();
 
   int neighflag, pack_flag;
   int nlocal,nall,nmax,newton_pair;
   int count, isuccess;
-  double alpha, beta, delta, cutsq;
+#ifdef HIP_OPT_CG_SOLVE_FUSED
+  F_FLOAT alpha[2];
+  F_FLOAT beta[2];
+#else
+  double alpha, beta;
+#endif
+  double delta, cutsq;
 
   void grow_arrays(int);
   void copy_arrays(int, int, int);
@@ -385,6 +469,21 @@ struct FixQEqReaxFFKokkosSparse22Functor  {
   }
 };
 
+#ifdef HIP_OPT_CG_SOLVE_FUSED
+template <class DeviceType>
+struct FixQEqReaxKokkosSparse22FusedFunctor  {
+  typedef DeviceType  device_type ;
+  FixQEqReaxKokkos<DeviceType> c;
+  FixQEqReaxKokkosSparse22FusedFunctor(FixQEqReaxKokkos<DeviceType>* c_ptr):c(*c_ptr) {
+    c.cleanup_copy();
+  };
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const int ii) const {
+    c.sparse22_fused_item(ii);
+  }
+};
+#endif
+
 template <class DeviceType,int NEIGHFLAG>
 struct FixQEqReaxFFKokkosSparse23Functor  {
   typedef DeviceType  device_type ;
@@ -411,6 +510,21 @@ struct FixQEqReaxFFKokkosSparse32Functor  {
   }
 };
 
+#ifdef HIP_OPT_CG_SOLVE_FUSED
+template <class DeviceType>
+struct FixQEqReaxKokkosSparse12_32Functor  {
+  typedef DeviceType  device_type ;
+  FixQEqReaxKokkos<DeviceType> c;
+  FixQEqReaxKokkosSparse12_32Functor(FixQEqReaxKokkos<DeviceType>* c_ptr):c(*c_ptr) {
+    c.cleanup_copy();
+  };
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const int ii) const {
+    c.sparse12_32_item(ii);
+  }
+};
+#endif
+
 template <class DeviceType,int NEIGHFLAG>
 struct FixQEqReaxFFKokkosSparse33Functor  {
   typedef DeviceType  device_type ;
@@ -436,6 +550,21 @@ struct FixQEqReaxFFKokkosVecSum2Functor  {
     c.vecsum2_item(ii);
   }
 };
+
+#ifdef HIP_OPT_CG_SOLVE_FUSED
+template <class DeviceType>
+struct FixQEqReaxKokkosVecSum2FusedFunctor  {
+  typedef DeviceType  device_type ;
+  FixQEqReaxKokkos<DeviceType> c;
+  FixQEqReaxKokkosVecSum2FusedFunctor(FixQEqReaxKokkos<DeviceType>* c_ptr):c(*c_ptr) {
+    c.cleanup_copy();
+  };
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const int ii) const {
+    c.vecsum2_fused_item(ii);
+  }
+};
+#endif
 
 template <class DeviceType>
 struct FixQEqReaxFFKokkosNorm1Functor  {
@@ -465,6 +594,23 @@ struct FixQEqReaxFFKokkosNorm2Functor  {
   }
 };
 
+#ifdef HIP_OPT_CG_SOLVE_FUSED
+// fused operator
+template <class DeviceType>
+struct FixQEqReaxKokkosNorm12Functor  {
+  typedef DeviceType  device_type ;
+  FixQEqReaxKokkos<DeviceType> c;
+  typedef F_FLOAT2 value_type;
+  FixQEqReaxKokkosNorm12Functor(FixQEqReaxKokkos<DeviceType>* c_ptr):c(*c_ptr) {
+    c.cleanup_copy();
+  };
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const int ii, value_type &tmp) const {
+    c.norm12_item(ii, tmp);
+  }
+};
+#endif
+
 template <class DeviceType>
 struct FixQEqReaxFFKokkosDot1Functor  {
   typedef DeviceType  device_type ;
@@ -493,6 +639,37 @@ struct FixQEqReaxFFKokkosDot2Functor  {
   }
 };
 
+#ifdef HIP_OPT_CG_SOLVE_FUSED
+// fused operators
+template <class DeviceType>
+struct FixQEqReaxKokkosDot11Functor  {
+  typedef DeviceType  device_type ;
+  FixQEqReaxKokkos<DeviceType> c;
+  typedef F_FLOAT2 value_type;
+  FixQEqReaxKokkosDot11Functor(FixQEqReaxKokkos<DeviceType>* c_ptr):c(*c_ptr) {
+    c.cleanup_copy();
+  };
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const int ii, value_type &tmp) const {
+    c.dot11_item(ii, tmp);
+  }
+};
+
+template <class DeviceType>
+struct FixQEqReaxKokkosDot22Functor  {
+  typedef DeviceType  device_type ;
+  FixQEqReaxKokkos<DeviceType> c;
+  typedef F_FLOAT2 value_type;
+  FixQEqReaxKokkosDot22Functor(FixQEqReaxKokkos<DeviceType>* c_ptr):c(*c_ptr) {
+    c.cleanup_copy();
+  };
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const int ii, value_type &tmp) const {
+    c.dot22_item(ii, tmp);
+  }
+};
+#endif
+
 template <class DeviceType>
 struct FixQEqReaxFFKokkosPrecon1Functor  {
   typedef DeviceType  device_type ;
@@ -519,6 +696,21 @@ struct FixQEqReaxFFKokkosPrecon2Functor  {
   }
 };
 
+#ifdef HIP_OPT_CG_SOLVE_FUSED
+template <class DeviceType>
+struct FixQEqReaxKokkosPrecon12Functor  {
+  typedef DeviceType  device_type ;
+  FixQEqReaxKokkos<DeviceType> c;
+  FixQEqReaxKokkosPrecon12Functor(FixQEqReaxKokkos<DeviceType>* c_ptr):c(*c_ptr) {
+    c.cleanup_copy();
+  };
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const int ii) const {
+    c.precon12_item(ii);
+  }
+};
+#endif
+
 template <class DeviceType>
 struct FixQEqReaxFFKokkosPreconFunctor  {
   typedef DeviceType  device_type ;
@@ -532,6 +724,22 @@ struct FixQEqReaxFFKokkosPreconFunctor  {
     tmp += c.precon_item(ii);
   }
 };
+
+#ifdef HIP_OPT_CG_SOLVE_FUSED
+template <class DeviceType>
+struct FixQEqReaxKokkosPreconFusedFunctor  {
+  typedef DeviceType  device_type ;
+  FixQEqReaxKokkos<DeviceType> c;
+  typedef F_FLOAT2 value_type;
+  FixQEqReaxKokkosPreconFusedFunctor(FixQEqReaxKokkos<DeviceType>* c_ptr):c(*c_ptr) {
+    c.cleanup_copy();
+  };
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const int ii, value_type &tmp) const {
+    c.precon_fused_item(ii, tmp);
+  }
+};
+#endif
 
 template <class DeviceType>
 struct FixQEqReaxFFKokkosVecAcc1Functor  {
@@ -573,8 +781,18 @@ struct FixQEqReaxFFKokkosCalculateQFunctor  {
     c.calculate_q_item(ii);
   }
 };
-
 }
+
+#ifdef HIP_OPT_CG_SOLVE_FUSED
+namespace Kokkos { //reduction identity must be defined in Kokkos namespace
+   template<>
+   struct reduction_identity< F_FLOAT2 > {
+      KOKKOS_FORCEINLINE_FUNCTION static F_FLOAT2 sum() {
+         return F_FLOAT2();
+      }
+   };
+}
+#endif
 
 #endif
 #endif

--- a/src/KOKKOS/kokkos_type.h
+++ b/src/KOKKOS/kokkos_type.h
@@ -501,6 +501,41 @@ struct s_FEV_FLOAT {
 };
 typedef struct s_FEV_FLOAT<6,3> FEV_FLOAT;
 
+struct s_FLOAT2 {
+  F_FLOAT v[2];
+
+  KOKKOS_INLINE_FUNCTION
+  s_FLOAT2() {
+    init();
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  s_FLOAT2(const s_FLOAT2 & rhs) {
+    for (int i = 0; i < 2; i++){
+      v[i] = rhs.v[i];
+    }
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void operator+=(const s_FLOAT2 &rhs) {
+    v[0] += rhs.v[0];
+    v[1] += rhs.v[1];
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void operator+=(const volatile s_FLOAT2 &rhs) volatile {
+    v[0] += rhs.v[0];
+    v[1] += rhs.v[1];
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void init() {
+    v[0] = 0;
+    v[1] = 0;
+  }
+};
+typedef struct s_FLOAT2 F_FLOAT2;
+
 #ifndef PREC_POS
 #define PREC_POS PRECISION
 #endif
@@ -731,6 +766,14 @@ typedef tdual_ffloat_1d::t_dev_const t_ffloat_1d_const;
 typedef tdual_ffloat_1d::t_dev_um t_ffloat_1d_um;
 typedef tdual_ffloat_1d::t_dev_const_um t_ffloat_1d_const_um;
 typedef tdual_ffloat_1d::t_dev_const_randomread t_ffloat_1d_randomread;
+
+// 1d F_FLOAT2 array n
+typedef Kokkos::DualView<F_FLOAT*[2], Kokkos::LayoutRight, LMPDeviceType> tdual_ffloat2_1d;
+typedef tdual_ffloat2_1d::t_dev t_ffloat2_1d;
+typedef tdual_ffloat2_1d::t_dev_const t_ffloat2_1d_const;
+typedef tdual_ffloat2_1d::t_dev_um t_ffloat2_1d_um;
+typedef tdual_ffloat2_1d::t_dev_const_um t_ffloat2_1d_const_um;
+typedef tdual_ffloat2_1d::t_dev_const_randomread t_ffloat2_1d_randomread;
 
 //2d F_FLOAT array n*m
 
@@ -1001,6 +1044,14 @@ typedef tdual_ffloat_1d::t_host_const t_ffloat_1d_const;
 typedef tdual_ffloat_1d::t_host_um t_ffloat_1d_um;
 typedef tdual_ffloat_1d::t_host_const_um t_ffloat_1d_const_um;
 typedef tdual_ffloat_1d::t_host_const_randomread t_ffloat_1d_randomread;
+
+// 1d F_FLOAT2 array n
+typedef Kokkos::DualView<F_FLOAT*[2], Kokkos::LayoutRight, LMPDeviceType> tdual_ffloat2_1d;
+typedef tdual_ffloat2_1d::t_host t_ffloat2_1d;
+typedef tdual_ffloat2_1d::t_host_const t_ffloat2_1d_const;
+typedef tdual_ffloat2_1d::t_host_um t_ffloat2_1d_um;
+typedef tdual_ffloat2_1d::t_host_const_um t_ffloat2_1d_const_um;
+typedef tdual_ffloat2_1d::t_host_const_randomread t_ffloat2_1d_randomread;
 
 //2d F_FLOAT array n*m
 typedef Kokkos::DualView<F_FLOAT**, Kokkos::LayoutRight, LMPDeviceType> tdual_ffloat_2d;

--- a/src/KOKKOS/pair_reaxff_kokkos.cpp
+++ b/src/KOKKOS/pair_reaxff_kokkos.cpp
@@ -1416,7 +1416,11 @@ void PairReaxFFKokkos<DeviceType>::operator()(PairReaxFFComputeLJCoulomb<NEIGHFL
            // Coulomb energy/force
            const F_FLOAT shld = paramstwbp(itype,jtype).gamma;
            const F_FLOAT denom1 = rij * rij * rij + shld;
+           #ifdef HIP_OPT_USE_LESS_MATH
+           const F_FLOAT denom3 = cbrt(denom1);
+           #else
            const F_FLOAT denom3 = pow(denom1,0.3333333333333);
+           #endif
            const F_FLOAT ecoul = C_ele * qi*qj*Tap/denom3;
            const F_FLOAT fcoul = C_ele * qi*qj*(dTap-Tap*rij/denom1)/denom3;
 

--- a/src/KOKKOS/pair_reaxff_kokkos.cpp
+++ b/src/KOKKOS/pair_reaxff_kokkos.cpp
@@ -1273,9 +1273,9 @@ void PairReaxFFKokkos<DeviceType>::operator()(PairReaxFFComputeLJCoulomb<NEIGHFL
   fxtmp = fytmp = fztmp = 0.0;
 #ifdef HIP_OPT_PAIRREAXLJCOULOMB_BLOCKING
 
-  unsigned short int BLK_SZ=80;
+  const unsigned short int BLK_SZ=64;
   unsigned short int nnz;
-  unsigned short int selected_jj[80];
+  unsigned short int selected_jj[BLK_SZ];
   int jj_current = 0;
 
   while (jj_current < jnum) {
@@ -2068,9 +2068,9 @@ void PairReaxFFKokkos<DeviceType>::operator()(PairReaxBuildListsHalf<NEIGHFLAG>,
 
   #ifdef HIP_OPT_PAIRREAXBUILDLISTSHALF_BLOCKING
 
-  unsigned short int BLK_SZ=80;
+  const unsigned short int BLK_SZ=64;
   unsigned short int nnz;
-  unsigned short int selected_jj[80];
+  unsigned short int selected_jj[BLK_SZ];
   unsigned short int jj_current = 0;
 
 
@@ -3698,9 +3698,9 @@ void PairReaxFFKokkos<DeviceType>::operator()(PairReaxFFComputeTorsion_with_BLOC
   F_FLOAT CdDelta_i = 0.0;
 
 
-  unsigned char BLK_SZ=1;
-  unsigned char nnz_jj;
-  unsigned char selected_jj[1];
+  const unsigned short int BLK_SZ=8;
+  unsigned short int nnz_jj;
+  unsigned short int selected_jj[BLK_SZ];
   #ifdef HIP_OPT_TORSION_PREVIEW
   unsigned int jj_current = jj_start;
   #else
@@ -3788,9 +3788,8 @@ void PairReaxFFKokkos<DeviceType>::operator()(PairReaxFFComputeTorsion_with_BLOC
       for(int k = 0; k < 3; k++) fjtmp[k] = 0.0;
       F_FLOAT CdDelta_j = 0.0;
 
-      unsigned char nnz_kk;
-
-      unsigned char selected_kk[1];
+      unsigned short int nnz_kk;
+      unsigned short int selected_kk[BLK_SZ];
       #ifdef HIP_OPT_TORSION_PREVIEW
       unsigned int kk_current = kk_start;
       #else


### PR DESCRIPTION
Contains the remaining optimizations we had internally, essentially:

- Some tuned blocking sizes for the "blocking" kernels in pair_reaxff [note: in general, the LJCoul blocking tends to be slightly slower and I usually turn it off, the blocking size here is simply the "best" of the slightly degraded perf.]
- Implement a fused CG solve in fix/qeq (enabled by -DHIP_OPT_CG_SOLVE_FUSED) that will step both CG solve loops (i.e., `cg_solve1` and `cg_solve2`) in the same kernel.  This significantly reduces the cost of MPI comms by reducing the # of halo-exchanges (~by a third), but makes the SpMV's a bit more expensive.
- Add another `cbrt` call to `-DHIP_OPT_USE_LESS_MATH`