### PR TITLE
Small update to LAMMPS PR #3555 branch for consistency and to fix compilation errors

### DIFF
--- a/src/AMOEBA/atom_vec_amoeba.h
+++ b/src/AMOEBA/atom_vec_amoeba.h
@@ -24,7 +24,7 @@ AtomStyle(amoeba,AtomVecAmoeba);
 
 namespace LAMMPS_NS {
 
-class AtomVecAmoeba : public AtomVec {
+class AtomVecAmoeba : virtual public AtomVec {
  public:
   AtomVecAmoeba(class LAMMPS *);
   ~AtomVecAmoeba() override;

--- a/src/ASPHERE/pair_ylz.cpp
+++ b/src/ASPHERE/pair_ylz.cpp
@@ -256,7 +256,7 @@ void PairYLZ::coeff(int narg, char **arg)
 
 void PairYLZ::init_style()
 {
-  avec = (AtomVecEllipsoid *) atom->style_match("ellipsoid");
+  avec = dynamic_cast<AtomVecEllipsoid *>(atom->style_match("ellipsoid"));
   if (!avec) error->all(FLERR, "Pair style ylz requires atom style ellipsoid");
 
   neighbor->request(this, instance_me);

--- a/src/AWPMD/atom_vec_wavepacket.h
+++ b/src/AWPMD/atom_vec_wavepacket.h
@@ -24,7 +24,7 @@ AtomStyle(wavepacket,AtomVecWavepacket);
 
 namespace LAMMPS_NS {
 
-class AtomVecWavepacket : public AtomVec {
+class AtomVecWavepacket : virtual public AtomVec {
  public:
   AtomVecWavepacket(class LAMMPS *);
 

--- a/src/BPM/atom_vec_bpm_sphere.h
+++ b/src/BPM/atom_vec_bpm_sphere.h
@@ -24,7 +24,7 @@ AtomStyle(bpm/sphere,AtomVecBPMSphere);
 
 namespace LAMMPS_NS {
 
-class AtomVecBPMSphere : public AtomVec {
+class AtomVecBPMSphere : virtual public AtomVec {
  public:
   AtomVecBPMSphere(class LAMMPS *);
   void process_args(int, char **) override;

--- a/src/CG-DNA/atom_vec_oxdna.h
+++ b/src/CG-DNA/atom_vec_oxdna.h
@@ -24,7 +24,7 @@ AtomStyle(oxdna,AtomVecOxdna);
 
 namespace LAMMPS_NS {
 
-class AtomVecOxdna : public AtomVec {
+class AtomVecOxdna : virtual public AtomVec {
  public:
   AtomVecOxdna(class LAMMPS *);
 

--- a/src/DIELECTRIC/atom_vec_dielectric.h
+++ b/src/DIELECTRIC/atom_vec_dielectric.h
@@ -24,7 +24,7 @@ AtomStyle(dielectric,AtomVecDielectric);
 
 namespace LAMMPS_NS {
 
-class AtomVecDielectric : public AtomVec {
+class AtomVecDielectric : virtual public AtomVec {
   friend class PairLJCutCoulDebyeDielectric;
   friend class PairLJLongCoulLongDielectric;
 

--- a/src/DIPOLE/atom_vec_dipole.h
+++ b/src/DIPOLE/atom_vec_dipole.h
@@ -24,7 +24,7 @@ AtomStyle(dipole,AtomVecDipole);
 
 namespace LAMMPS_NS {
 
-class AtomVecDipole : public AtomVec {
+class AtomVecDipole : virtual public AtomVec {
  public:
   AtomVecDipole(class LAMMPS *);
 

--- a/src/DPD-MESO/atom_vec_edpd.h
+++ b/src/DPD-MESO/atom_vec_edpd.h
@@ -24,7 +24,7 @@ AtomStyle(edpd,AtomVecEDPD);
 
 namespace LAMMPS_NS {
 
-class AtomVecEDPD : public AtomVec {
+class AtomVecEDPD : virtual public AtomVec {
  public:
   AtomVecEDPD(class LAMMPS *);
   void init() override;

--- a/src/DPD-MESO/atom_vec_mdpd.h
+++ b/src/DPD-MESO/atom_vec_mdpd.h
@@ -24,7 +24,7 @@ AtomStyle(mdpd,AtomVecMDPD);
 
 namespace LAMMPS_NS {
 
-class AtomVecMDPD : public AtomVec {
+class AtomVecMDPD : virtual public AtomVec {
  public:
   AtomVecMDPD(class LAMMPS *);
   void init() override;

--- a/src/DPD-MESO/atom_vec_tdpd.h
+++ b/src/DPD-MESO/atom_vec_tdpd.h
@@ -24,7 +24,7 @@ AtomStyle(tdpd,AtomVecTDPD);
 
 namespace LAMMPS_NS {
 
-class AtomVecTDPD : public AtomVec {
+class AtomVecTDPD : virtual public AtomVec {
  public:
   AtomVecTDPD(class LAMMPS *);
   void process_args(int, char **) override;

--- a/src/EFF/atom_vec_electron.h
+++ b/src/EFF/atom_vec_electron.h
@@ -24,7 +24,7 @@ AtomStyle(electron,AtomVecElectron);
 
 namespace LAMMPS_NS {
 
-class AtomVecElectron : public AtomVec {
+class AtomVecElectron : virtual public AtomVec {
  public:
   AtomVecElectron(class LAMMPS *);
 

--- a/src/MACHDYN/atom_vec_smd.h
+++ b/src/MACHDYN/atom_vec_smd.h
@@ -35,7 +35,7 @@ AtomStyle(smd,AtomVecSMD);
 
 namespace LAMMPS_NS {
 
-class AtomVecSMD : public AtomVec {
+class AtomVecSMD : virtual public AtomVec {
  public:
   AtomVecSMD(class LAMMPS *);
 

--- a/src/MESONT/atom_vec_mesont.h
+++ b/src/MESONT/atom_vec_mesont.h
@@ -26,7 +26,7 @@ AtomStyle(mesont,AtomVecMesoNT);
 
 namespace LAMMPS_NS {
 
-class AtomVecMesoNT : public AtomVec {
+class AtomVecMesoNT : virtual public AtomVec {
  public:
   AtomVecMesoNT(class LAMMPS *);
 };

--- a/src/MOLECULE/atom_vec_template.h
+++ b/src/MOLECULE/atom_vec_template.h
@@ -24,7 +24,7 @@ AtomStyle(template,AtomVecTemplate);
 
 namespace LAMMPS_NS {
 
-class AtomVecTemplate : public AtomVec {
+class AtomVecTemplate : virtual public AtomVec {
  public:
   AtomVecTemplate(class LAMMPS *);
 

--- a/src/PERI/atom_vec_peri.h
+++ b/src/PERI/atom_vec_peri.h
@@ -24,7 +24,7 @@ AtomStyle(peri,AtomVecPeri);
 
 namespace LAMMPS_NS {
 
-class AtomVecPeri : public AtomVec {
+class AtomVecPeri : virtual public AtomVec {
  public:
   AtomVecPeri(class LAMMPS *);
 

--- a/src/SPH/atom_vec_sph.h
+++ b/src/SPH/atom_vec_sph.h
@@ -24,7 +24,7 @@ AtomStyle(sph,AtomVecSPH);
 
 namespace LAMMPS_NS {
 
-class AtomVecSPH : public AtomVec {
+class AtomVecSPH : virtual public AtomVec {
  public:
   AtomVecSPH(class LAMMPS *);
 

--- a/unittest/formats/test_atom_styles.cpp
+++ b/unittest/formats/test_atom_styles.cpp
@@ -1147,7 +1147,7 @@ TEST_F(AtomStyleTest, ellipsoid)
     auto type      = lmp->atom->type;
     auto ellipsoid = lmp->atom->ellipsoid;
     auto rmass     = lmp->atom->rmass;
-    auto avec      = (AtomVecEllipsoid *)lmp->atom->avec;
+    auto avec      = dynamic_cast<AtomVecEllipsoid *>(lmp->atom->avec);
     auto bonus     = avec->bonus;
     EXPECT_NEAR(x[GETIDX(1)][0], -2.0, EPSILON);
     EXPECT_NEAR(x[GETIDX(1)][1], 2.0, EPSILON);
@@ -1258,7 +1258,7 @@ TEST_F(AtomStyleTest, ellipsoid)
     type      = lmp->atom->type;
     ellipsoid = lmp->atom->ellipsoid;
     rmass     = lmp->atom->rmass;
-    avec      = (AtomVecEllipsoid *)lmp->atom->avec;
+    avec      = dynamic_cast<AtomVecEllipsoid *>(lmp->atom->avec);
     bonus     = avec->bonus;
     ASSERT_EQ(type[GETIDX(1)], 1);
     ASSERT_EQ(type[GETIDX(3)], 2);
@@ -1323,7 +1323,7 @@ TEST_F(AtomStyleTest, ellipsoid)
 
     ellipsoid = lmp->atom->ellipsoid;
     rmass     = lmp->atom->rmass;
-    avec      = (AtomVecEllipsoid *)lmp->atom->avec;
+    avec      = dynamic_cast<AtomVecEllipsoid *>(lmp->atom->avec);
     bonus     = avec->bonus;
     ASSERT_EQ(type[GETIDX(1)], 1);
     ASSERT_EQ(type[GETIDX(2)], 3);
@@ -1476,7 +1476,7 @@ TEST_F(AtomStyleTest, line)
     auto type  = lmp->atom->type;
     auto line  = lmp->atom->line;
     auto rmass = lmp->atom->rmass;
-    auto avec  = (AtomVecLine *)lmp->atom->avec;
+    auto avec  = dynamic_cast<AtomVecLine *>(lmp->atom->avec);
     auto bonus = avec->bonus;
     EXPECT_NEAR(x[GETIDX(1)][0], -2.0, EPSILON);
     EXPECT_NEAR(x[GETIDX(1)][1], 2.0, EPSILON);
@@ -1569,7 +1569,7 @@ TEST_F(AtomStyleTest, line)
     type  = lmp->atom->type;
     line  = lmp->atom->line;
     rmass = lmp->atom->rmass;
-    avec  = (AtomVecLine *)lmp->atom->avec;
+    avec  = dynamic_cast<AtomVecLine *>(lmp->atom->avec);
     bonus = avec->bonus;
     ASSERT_EQ(type[GETIDX(1)], 1);
     ASSERT_EQ(type[GETIDX(3)], 2);
@@ -1614,7 +1614,7 @@ TEST_F(AtomStyleTest, line)
 
     line  = lmp->atom->line;
     rmass = lmp->atom->rmass;
-    avec  = (AtomVecLine *)lmp->atom->avec;
+    avec  = dynamic_cast<AtomVecLine *>(lmp->atom->avec);
     bonus = avec->bonus;
     ASSERT_EQ(type[GETIDX(1)], 1);
     ASSERT_EQ(type[GETIDX(2)], 3);
@@ -1760,7 +1760,7 @@ TEST_F(AtomStyleTest, tri)
     auto tri    = lmp->atom->tri;
     auto rmass  = lmp->atom->rmass;
     auto radius = lmp->atom->radius;
-    auto avec   = (AtomVecTri *)lmp->atom->avec;
+    auto avec   = dynamic_cast<AtomVecTri *>(lmp->atom->avec);
     auto bonus  = avec->bonus;
     EXPECT_NEAR(x[GETIDX(1)][0], -2.0, EPSILON);
     EXPECT_NEAR(x[GETIDX(1)][1], 2.0, EPSILON);
@@ -1914,7 +1914,7 @@ TEST_F(AtomStyleTest, tri)
     tri    = lmp->atom->tri;
     rmass  = lmp->atom->rmass;
     radius = lmp->atom->radius;
-    avec   = (AtomVecTri *)lmp->atom->avec;
+    avec   = dynamic_cast<AtomVecTri *>(lmp->atom->avec);
     bonus  = avec->bonus;
     ASSERT_EQ(type[GETIDX(1)], 1);
     ASSERT_EQ(type[GETIDX(3)], 2);
@@ -2023,7 +2023,7 @@ TEST_F(AtomStyleTest, tri)
 
     tri   = lmp->atom->tri;
     rmass = lmp->atom->rmass;
-    avec  = (AtomVecTri *)lmp->atom->avec;
+    avec  = dynamic_cast<AtomVecTri *>(lmp->atom->avec);
     bonus = avec->bonus;
     ASSERT_EQ(type[GETIDX(1)], 1);
     ASSERT_EQ(type[GETIDX(2)], 3);
@@ -2081,7 +2081,7 @@ TEST_F(AtomStyleTest, body_nparticle)
 
     ASSERT_ATOM_STATE_EQ(lmp->atom, expected);
 
-    auto avec = (AtomVecBody *)lmp->atom->avec;
+    auto avec = dynamic_cast<AtomVecBody *>(lmp->atom->avec);
     ASSERT_NE(lmp->atom->avec, nullptr);
     ASSERT_NE(avec->bptr, nullptr);
     ASSERT_THAT(std::string(avec->bptr->style), Eq("nparticle"));
@@ -2344,7 +2344,7 @@ TEST_F(AtomStyleTest, body_nparticle)
     rmass  = lmp->atom->rmass;
     radius = lmp->atom->radius;
     angmom = lmp->atom->angmom;
-    avec   = (AtomVecBody *)lmp->atom->avec;
+    avec   = dynamic_cast<AtomVecBody *>(lmp->atom->avec);
     bonus  = avec->bonus;
     EXPECT_NEAR(x[GETIDX(1)][0], -2.0, EPSILON);
     EXPECT_NEAR(x[GETIDX(1)][1], 2.0, EPSILON);
@@ -2484,7 +2484,7 @@ TEST_F(AtomStyleTest, body_nparticle)
     command("replicate 1 1 2");
     END_HIDE_OUTPUT();
     ASSERT_THAT(std::string(lmp->atom->atom_style), Eq("body"));
-    avec = (AtomVecBody *)lmp->atom->avec;
+    avec = dynamic_cast<AtomVecBody *>(lmp->atom->avec);
     ASSERT_THAT(std::string(avec->bptr->style), Eq("nparticle"));
     ASSERT_NE(lmp->atom->avec, nullptr);
     ASSERT_EQ(lmp->atom->natoms, 8);
@@ -2599,7 +2599,7 @@ TEST_F(AtomStyleTest, body_nparticle)
     body   = lmp->atom->body;
     rmass  = lmp->atom->rmass;
     radius = lmp->atom->radius;
-    avec   = (AtomVecBody *)lmp->atom->avec;
+    avec   = dynamic_cast<AtomVecBody *>(lmp->atom->avec);
     bonus  = avec->bonus;
     ASSERT_EQ(type[GETIDX(1)], 1);
     ASSERT_EQ(type[GETIDX(2)], 3);
@@ -3048,7 +3048,7 @@ TEST_F(AtomStyleTest, template_charge)
 
     ASSERT_ATOM_STATE_EQ(lmp->atom, expected);
 
-    auto hybrid = (AtomVecHybrid *)lmp->atom->avec;
+    auto hybrid = dynamic_cast<AtomVecHybrid *>(lmp->atom->avec);
     ASSERT_THAT(std::string(lmp->atom->atom_style), Eq("hybrid"));
     ASSERT_EQ(hybrid->nstyles, 2);
     ASSERT_THAT(std::string(hybrid->keywords[0]), Eq("template"));
@@ -3079,7 +3079,7 @@ TEST_F(AtomStyleTest, template_charge)
     command("pair_coeff * *");
     END_HIDE_OUTPUT();
     ASSERT_NE(lmp->atom->avec, nullptr);
-    hybrid = (AtomVecHybrid *)lmp->atom->avec;
+    hybrid = dynamic_cast<AtomVecHybrid *>(lmp->atom->avec);
     ASSERT_THAT(std::string(lmp->atom->atom_style), Eq("hybrid"));
     ASSERT_EQ(hybrid->nstyles, 2);
     ASSERT_THAT(std::string(hybrid->keywords[0]), Eq("template"));
@@ -4189,7 +4189,7 @@ TEST_F(AtomStyleTest, full_ellipsoid)
 
     ASSERT_ATOM_STATE_EQ(lmp->atom, expected);
 
-    auto hybrid = (AtomVecHybrid *)lmp->atom->avec;
+    auto hybrid = dynamic_cast<AtomVecHybrid *>(lmp->atom->avec);
     ASSERT_THAT(std::string(lmp->atom->atom_style), Eq("hybrid"));
     ASSERT_EQ(hybrid->nstyles, 2);
     ASSERT_THAT(std::string(hybrid->keywords[0]), Eq("full"));
@@ -4276,7 +4276,7 @@ TEST_F(AtomStyleTest, full_ellipsoid)
     END_HIDE_OUTPUT();
     ASSERT_THAT(std::string(lmp->atom->atom_style), Eq("hybrid"));
     ASSERT_NE(lmp->atom->avec, nullptr);
-    hybrid = (AtomVecHybrid *)lmp->atom->avec;
+    hybrid = dynamic_cast<AtomVecHybrid *>(lmp->atom->avec);
     ASSERT_EQ(hybrid->nstyles, 2);
     ASSERT_THAT(std::string(hybrid->keywords[0]), Eq("full"));
     ASSERT_THAT(std::string(hybrid->keywords[1]), Eq("ellipsoid"));
@@ -4306,7 +4306,7 @@ TEST_F(AtomStyleTest, full_ellipsoid)
     auto ellipsoid = lmp->atom->ellipsoid;
     auto rmass     = lmp->atom->rmass;
 
-    auto avec  = (AtomVecEllipsoid *)hybrid->styles[1];
+    auto avec  = dynamic_cast<AtomVecEllipsoid *>(hybrid->styles[1]);
     auto bonus = avec->bonus;
     EXPECT_NEAR(x[GETIDX(1)][0], -2.0, EPSILON);
     EXPECT_NEAR(x[GETIDX(1)][1], 2.0, EPSILON);
@@ -4408,7 +4408,7 @@ TEST_F(AtomStyleTest, full_ellipsoid)
     command("replicate 1 1 2 bbox");
     END_HIDE_OUTPUT();
     ASSERT_THAT(std::string(lmp->atom->atom_style), Eq("hybrid"));
-    hybrid = (AtomVecHybrid *)lmp->atom->avec;
+    hybrid = dynamic_cast<AtomVecHybrid *>(lmp->atom->avec);
     ASSERT_EQ(hybrid->nstyles, 2);
     ASSERT_THAT(std::string(hybrid->keywords[0]), Eq("full"));
     ASSERT_THAT(std::string(hybrid->keywords[1]), Eq("ellipsoid"));
@@ -4429,7 +4429,7 @@ TEST_F(AtomStyleTest, full_ellipsoid)
     type      = lmp->atom->type;
     ellipsoid = lmp->atom->ellipsoid;
     rmass     = lmp->atom->rmass;
-    avec      = (AtomVecEllipsoid *)hybrid->styles[1];
+    avec      = dynamic_cast<AtomVecEllipsoid *>(hybrid->styles[1]);
     bonus     = avec->bonus;
     ASSERT_EQ(type[GETIDX(1)], 1);
     ASSERT_EQ(type[GETIDX(3)], 2);
@@ -4494,8 +4494,8 @@ TEST_F(AtomStyleTest, full_ellipsoid)
 
     ellipsoid = lmp->atom->ellipsoid;
     rmass     = lmp->atom->rmass;
-    hybrid    = (AtomVecHybrid *)lmp->atom->avec;
-    avec      = (AtomVecEllipsoid *)hybrid->styles[1];
+    hybrid    = dynamic_cast<AtomVecHybrid *>(lmp->atom->avec);
+    avec      = dynamic_cast<AtomVecEllipsoid *>(hybrid->styles[1]);
     bonus     = avec->bonus;
     ASSERT_EQ(type[GETIDX(1)], 1);
     ASSERT_EQ(type[GETIDX(2)], 3);
@@ -4839,7 +4839,7 @@ TEST_F(AtomStyleTest, oxdna)
 
     ASSERT_ATOM_STATE_EQ(lmp->atom, expected);
 
-    auto hybrid = (AtomVecHybrid *)lmp->atom->avec;
+    auto hybrid = dynamic_cast<AtomVecHybrid *>(lmp->atom->avec);
     ASSERT_THAT(std::string(lmp->atom->atom_style), Eq("hybrid"));
     ASSERT_EQ(hybrid->nstyles, 3);
     ASSERT_THAT(std::string(hybrid->keywords[0]), Eq("bond"));
@@ -5014,7 +5014,7 @@ TEST_F(AtomStyleTest, oxdna)
 
     ASSERT_THAT(std::string(lmp->atom->atom_style), Eq("hybrid"));
     ASSERT_NE(lmp->atom->avec, nullptr);
-    hybrid = (AtomVecHybrid *)lmp->atom->avec;
+    hybrid = dynamic_cast<AtomVecHybrid *>(lmp->atom->avec);
 
     ASSERT_EQ(hybrid->nstyles, 3);
     ASSERT_THAT(std::string(hybrid->keywords[0]), Eq("bond"));
@@ -5058,7 +5058,7 @@ TEST_F(AtomStyleTest, oxdna)
     auto ellipsoid = lmp->atom->ellipsoid;
     auto rmass     = lmp->atom->rmass;
 
-    auto avec  = (AtomVecEllipsoid *)hybrid->styles[1];
+    auto avec  = dynamic_cast<AtomVecEllipsoid *>(hybrid->styles[1]);
     auto bonus = avec->bonus;
 
     EXPECT_NEAR(x[GETIDX(1)][0], -0.33741452300167507, EPSILON);


### PR DESCRIPTION
This pull request makes all AtomVec inheritance consistently virtual.
Also compilation errors when casting from AtomVec to an inherited class a dynamic cast is now required. This is fixed in a couple of cases.