### PR TITLE
Fix long-range spin dipole energy, forces, and pressure (issue #4717)

### DIFF
--- a/src/KSPACE/ewald_dipole_spin.cpp
+++ b/src/KSPACE/ewald_dipole_spin.cpp
@@ -46,7 +46,7 @@ EwaldDipoleSpin::EwaldDipoleSpin(LAMMPS *lmp) :
 
   hbar = force->hplanck/MY_2PI;                 // eV/(rad.THz)
   mub = 9.274e-4;                               // in A.Ang^2
-  mu_0 = 785.15;                                // in eV/Ang/A^2
+  mu_0 = 784.15;                                // in eV/Ang/A^2
   mub2mu0 = mub * mub * mu_0 / (4.0*MY_PI);     // in eV.Ang^3
   mub2mu0hbinv = mub2mu0 / hbar;                // in rad.THz
 }
@@ -446,9 +446,16 @@ void EwaldDipoleSpin::compute(int eflag, int vflag)
     f[i][0] += spscale * ek[i][0];
     f[i][1] += spscale * ek[i][1];
     if (slabflag != 2) f[i][2] += spscale * ek[i][2];
-    fm_long[i][0] += spscale2 * tk[i][0];
-    fm_long[i][1] += spscale2 * tk[i][1];
-    if (slabflag != 2) fm_long[i][2] += spscale2 * tk[i][2];
+
+    // reciprocal-space contribution to the magnetic precession vector
+    // fm_i = -(1/hbar) dE/ds_i = -spscale2 * sp[i][3] * tk[i].
+    // the sp[i][3] factor (spin norm g_i) is needed because tk[i] only
+    // carries the contributions of the source spins, and the minus sign
+    // follows the dipole torque convention t = -muscale*(mu x tk)
+
+    fm_long[i][0] -= sp[i][3] * spscale2 * tk[i][0];
+    fm_long[i][1] -= sp[i][3] * spscale2 * tk[i][1];
+    if (slabflag != 2) fm_long[i][2] -= sp[i][3] * spscale2 * tk[i][2];
   }
 
   // sum global energy across Kspace vevs and add in volume-dependent term
@@ -790,11 +797,14 @@ void EwaldDipoleSpin::slabcorr()
   }
 
   // add on mag. force corrections
+  // fm_long is the precession vector, so use spscale2 (= mub2mu0hbinv)
+  // and weight by the per-atom spin norm sp[i][3]
 
-  double ffact = spscale * (-4.0*MY_PI/volume);
+  const double spscale2 = mub2mu0hbinv * scale;
+  double ffact = spscale2 * (-4.0*MY_PI/volume);
   double **fm_long = atom->fm_long;
   for (int i = 0; i < nlocal; i++) {
-    fm_long[i][2] += ffact * spin_all;
+    fm_long[i][2] += sp[i][3] * ffact * spin_all;
   }
 }
 
@@ -824,8 +834,10 @@ void EwaldDipoleSpin::spsum_musq()
     MPI_Allreduce(&musum_local,&musum,1,MPI_DOUBLE,MPI_SUM,world);
     MPI_Allreduce(&musqsum_local,&musqsum,1,MPI_DOUBLE,MPI_SUM,world);
 
-    //mu2 = musqsum * mub2mu0;
-    mu2 = musqsum;
+    // scale squared moment by the dipolar prefactor (analog of qqrd2e for
+    // charges/dipoles) so the g_ewald estimate and rms error are correct
+
+    mu2 = musqsum * mub2mu0;
   }
 
   if (mu2 == 0 && comm->me == 0)

--- a/src/KSPACE/pppm_dipole_spin.cpp
+++ b/src/KSPACE/pppm_dipole_spin.cpp
@@ -48,7 +48,7 @@ PPPMDipoleSpin::PPPMDipoleSpin(LAMMPS *lmp) :
 
   hbar = force->hplanck/MY_2PI;                 // eV/(rad.THz)
   mub = 9.274e-4;                               // in A.Ang^2
-  mu_0 = 785.15;                                // in eV/Ang/A^2
+  mu_0 = 784.15;                                // in eV/Ang/A^2
   mub2mu0 = mub * mub * mu_0 / (4.0*MY_PI);     // in eV.Ang^3
   mub2mu0hbinv = mub2mu0 / hbar;                // in rad.THz
 }
@@ -515,11 +515,14 @@ void PPPMDipoleSpin::fieldforce_ik_spin()
     f[i][2] += spfactor*(vxz*spx + vyz*spy + vzz*spz);
 
     // store long-range mag. precessions
+    // fm_i = (g_i/hbar) * B_i, so weight the interpolated field by the
+    // per-atom spin norm sp[i][3] (sign follows the dipole torque
+    // convention t = +mufactor*(mu x E) used in fieldforce_ik_dipole)
 
     const double spfactorh = mub2mu0hbinv * scale;
-    fm_long[i][0] += spfactorh*ex;
-    fm_long[i][1] += spfactorh*ey;
-    fm_long[i][2] += spfactorh*ez;
+    fm_long[i][0] += sp[i][3]*spfactorh*ex;
+    fm_long[i][1] += sp[i][3]*spfactorh*ey;
+    fm_long[i][2] += sp[i][3]*spfactorh*ez;
   }
 }
 
@@ -659,11 +662,14 @@ void PPPMDipoleSpin::slabcorr()
   }
 
   // add on mag. force corrections
+  // fm_long is the precession vector, so use spscale2 (= mub2mu0hbinv)
+  // and weight by the per-atom spin norm sp[i][3]
 
-  double ffact = spscale * (-4.0*MY_PI/volume);
+  const double spscale2 = mub2mu0hbinv * scale;
+  double ffact = spscale2 * (-4.0*MY_PI/volume);
   double **fm_long = atom->fm_long;
   for (int i = 0; i < nlocal; i++) {
-    fm_long[i][2] += ffact * spin_all;
+    fm_long[i][2] += sp[i][3] * ffact * spin_all;
   }
 }
 
@@ -697,8 +703,10 @@ void PPPMDipoleSpin::spsum_spsq()
     MPI_Allreduce(&spsum_local,&musum,1,MPI_DOUBLE,MPI_SUM,world);
     MPI_Allreduce(&spsqsum_local,&musqsum,1,MPI_DOUBLE,MPI_SUM,world);
 
-    //mu2 = musqsum * mub2mu0;
-    mu2 = musqsum;
+    // scale squared moment by the dipolar prefactor (analog of qqrd2e for
+    // charges/dipoles) so the g_ewald estimate and rms error are correct
+
+    mu2 = musqsum * mub2mu0;
   }
 
   if (mu2 == 0 && comm->me == 0)

--- a/src/SPIN/pair_spin_dipole_cut.cpp
+++ b/src/SPIN/pair_spin_dipole_cut.cpp
@@ -268,7 +268,7 @@ void PairSpinDipoleCut::compute(int eflag, int vflag)
         fm[i][2] += fmi[2];
 
         if (evflag) ev_tally_xyz(i,j,nlocal,newton_pair,
-            evdwl,ecoul,fi[0],fi[1],fi[2],rij[0],rij[1],rij[2]);
+            evdwl,ecoul,fi[0],fi[1],fi[2],-rij[0],-rij[1],-rij[2]);
       }
     }
   }

--- a/src/SPIN/pair_spin_dipole_long.cpp
+++ b/src/SPIN/pair_spin_dipole_long.cpp
@@ -278,9 +278,9 @@ void PairSpinDipoleLong::compute(int eflag, int vflag)
         bij[2] = (3.0*bij[1] + pre2*expm2) * r2inv;
         bij[3] = (5.0*bij[2] + pre3*expm2) * r2inv;
 
-        compute_long(i,j,eij,bij,fmi,spi,spj);
+        compute_long(i,j,eij,bij,fmi,spi,spj,rsq);
         if (lattice_flag)
-          compute_long_mech(i,j,eij,bij,fmi,spi,spj);
+          compute_long_mech(i,j,eij,bij,fi,spi,spj,rsq);
 
         if (eflag) {
           if (rsq <= local_cut2) {
@@ -303,7 +303,7 @@ void PairSpinDipoleLong::compute(int eflag, int vflag)
         fm[i][2] += fmi[2];
 
         if (evflag) ev_tally_xyz(i,j,nlocal,newton_pair,
-            evdwl,ecoul,fi[0],fi[1],fi[2],rij[0],rij[1],rij[2]);
+            evdwl,ecoul,fi[0],fi[1],fi[2],-rij[0],-rij[1],-rij[2]);
 
       }
     }
@@ -415,7 +415,7 @@ void PairSpinDipoleLong::compute_single_pair(int ii, double fmi[3])
         bij[2] = (3.0*bij[1] + pre2*expm2) * r2inv;
         bij[3] = (5.0*bij[2] + pre3*expm2) * r2inv;
 
-        compute_long(ii,j,eij,bij,fmi,spi,spj);
+        compute_long(ii,j,eij,bij,fmi,spi,spj,rsq);
       }
     }
 
@@ -432,7 +432,7 @@ void PairSpinDipoleLong::compute_single_pair(int ii, double fmi[3])
 ------------------------------------------------------------------------- */
 
 void PairSpinDipoleLong::compute_long(int /* i */, int /* j */, double eij[3],
-    double bij[4], double fmi[3], double spi[4], double spj[4])
+    double bij[4], double fmi[3], double spi[4], double spj[4], double rsq)
 {
   double sjeij,pre;
   double b1,b2,gigj;
@@ -444,9 +444,14 @@ void PairSpinDipoleLong::compute_long(int /* i */, int /* j */, double eij[3],
   b1 = bij[1];
   b2 = bij[2];
 
-  fmi[0] += pre * (b2 * sjeij * eij[0] - b1 * spj[0]);
-  fmi[1] += pre * (b2 * sjeij * eij[1] - b1 * spj[1]);
-  fmi[2] += pre * (b2 * sjeij * eij[2] - b1 * spj[2]);
+  // screened real-space dipolar field: B2*r^2*(sj.eij)*eij - B1*sj
+  // the b2 (B2) term carries an extra factor of r^2 because (sj.eij)*eij
+  // is the unit-vector form of (sj.rij)*rij/r^2 (see compute_dipolar in
+  // pair_spin_dipole_cut for the unscreened g_ewald -> 0 limit)
+
+  fmi[0] += pre * (b2 * rsq * sjeij * eij[0] - b1 * spj[0]);
+  fmi[1] += pre * (b2 * rsq * sjeij * eij[1] - b1 * spj[1]);
+  fmi[2] += pre * (b2 * rsq * sjeij * eij[2] - b1 * spj[2]);
 }
 
 /* ----------------------------------------------------------------------
@@ -455,9 +460,9 @@ void PairSpinDipoleLong::compute_long(int /* i */, int /* j */, double eij[3],
 ------------------------------------------------------------------------- */
 
 void PairSpinDipoleLong::compute_long_mech(int /* i */, int /* j */, double eij[3],
-    double bij[4], double fi[3], double spi[4], double spj[4])
+    double bij[4], double fi[3], double spi[4], double spj[4], double rsq)
 {
-  double sisj,sieij,sjeij,b2,b3;
+  double sisj,sieij,sjeij,b2,b3,r;
   double g1,g2,g1b2_g2b3,gigj,pre;
 
   gigj = spi[3] * spj[3];
@@ -466,15 +471,22 @@ void PairSpinDipoleLong::compute_long_mech(int /* i */, int /* j */, double eij[
   sieij = spi[0]*eij[0] + spi[1]*eij[1] + spi[2]*eij[2];
   sjeij = spj[0]*eij[0] + spj[1]*eij[1] + spj[2]*eij[2];
 
+  // mechanical force from the screened real-space dipolar energy
+  // E = gigj*mub2mu0 * (B1*(si.sj) - B2*r^2*(si.eij)*(sj.eij))
+  // f_i = -dE/dr_i, using dB_n/dr = -r*B_{n+1}.  the (si.eij)*(sj.eij) term
+  // carries r^2 and the overall gradient brings an extra factor of r, so that
+  // this reduces to compute_dipolar_mech in the g_ewald -> 0 limit
+
   b2 = bij[2];
   b3 = bij[3];
+  r = sqrt(rsq);
   g1 = sisj;
-  g2 = -sieij*sjeij;
+  g2 = -rsq * sieij * sjeij;
   g1b2_g2b3 = g1*b2 + g2*b3;
 
-  fi[0] += pre * (eij[0] * g1b2_g2b3 + b2 * (sjeij*spi[0] + sieij*spj[0]));
-  fi[1] += pre * (eij[1] * g1b2_g2b3 + b2 * (sjeij*spi[1] + sieij*spj[1]));
-  fi[2] += pre * (eij[2] * g1b2_g2b3 + b2 * (sjeij*spi[2] + sieij*spj[2]));
+  fi[0] -= pre * r * (eij[0] * g1b2_g2b3 + b2 * (sjeij*spi[0] + sieij*spj[0]));
+  fi[1] -= pre * r * (eij[1] * g1b2_g2b3 + b2 * (sjeij*spi[1] + sieij*spj[1]));
+  fi[2] -= pre * r * (eij[2] * g1b2_g2b3 + b2 * (sjeij*spi[2] + sieij*spj[2]));
 }
 
 
@@ -509,7 +521,7 @@ void PairSpinDipoleLong::write_restart(FILE *fp)
     for (j = i; j <= atom->ntypes; j++) {
       fwrite(&setflag[i][j],sizeof(int),1,fp);
       if (setflag[i][j]) {
-        fwrite(&cut_spin_long[i][j],sizeof(int),1,fp);
+        fwrite(&cut_spin_long[i][j],sizeof(double),1,fp);
       }
     }
   }
@@ -533,7 +545,7 @@ void PairSpinDipoleLong::read_restart(FILE *fp)
       MPI_Bcast(&setflag[i][j],1,MPI_INT,0,world);
       if (setflag[i][j]) {
         if (me == 0) {
-          utils::sfread(FLERR,&cut_spin_long[i][j],sizeof(int),1,fp,nullptr,error);
+          utils::sfread(FLERR,&cut_spin_long[i][j],sizeof(double),1,fp,nullptr,error);
         }
         MPI_Bcast(&cut_spin_long[i][j],1,MPI_DOUBLE,0,world);
       }

--- a/src/SPIN/pair_spin_dipole_long.h
+++ b/src/SPIN/pair_spin_dipole_long.h
@@ -40,8 +40,8 @@ class PairSpinDipoleLong : public PairSpin {
   void compute(int, int) override;
   void compute_single_pair(int, double *) override;
 
-  void compute_long(int, int, double *, double *, double *, double *, double *);
-  void compute_long_mech(int, int, double *, double *, double *, double *, double *);
+  void compute_long(int, int, double *, double *, double *, double *, double *, double);
+  void compute_long_mech(int, int, double *, double *, double *, double *, double *, double);
 
   void write_restart(FILE *) override;
   void read_restart(FILE *) override;


### PR DESCRIPTION
Fixes the `spin/dipole/long` pair style and its `ewald/dipole/spin` and `pppm/dipole/spin` kspace partners, which gave dipolar energies that disagreed with `spin/dipole/cut` and the analytical result, and were not independent of the real-space cutoff when shifting work between the short- and long-range parts (LAMMPS issue #4717).

## Real-space pair (`pair_spin_dipole_long`)
- **`compute_long`**: the screened dipolar field is `B2*r^2*(sj.eij)*eij - B1*sj`. The `r^2` (`rsq`) factor on the `B2` term was missing, which corrupted both the precession field and the energy (`evdwl = -0.5*hbar*sp.fmi`). With the fix this reduces to `compute_dipolar` in the cut style as `g_ewald -> 0`. This is the primary cause of the reported wrong energy.
- **`compute_long_mech`** was accumulated into `fmi` instead of `fi` (so there were no real-space mechanical forces at all), and was missing the `r^2` factor on the `(si.eij)(sj.eij)` term, the overall factor of `r`, and the sign. Both helpers now take `rsq`.
- The **pair virial** was tallied with `rij = x_j - x_i` instead of `x_i - x_j`, giving the wrong sign (attractive pairs reported positive pressure) and preventing cancellation against the reciprocal-space virial. The same one-line sign fix is applied to `spin/dipole/cut`.
- `write_restart`/`read_restart` wrote/read the `double` cutoff with `sizeof(int)`.

## Reciprocal space (`ewald_dipole_spin`, `pppm_dipole_spin`)
- `fm_long` (the kspace precession contribution) was missing the per-atom spin norm `sp[i][3]`; ewald additionally had the wrong sign. The slab corrections used `spscale` instead of `spscale2` and also dropped `sp[i][3]`.
- `mu_0` was `785.15` in the kspace styles but `784.15` in the pair styles, so the real- and reciprocal-space prefactors did not match.
- `mu2` used in the `g_ewald` estimate dropped the `mub2mu0` prefactor.

## Verification
Built with SPIN + KSPACE (+ DIPOLE for cross-checks) and confirmed on the issue reproducer and periodic spin lattices that:
- the total energy, mechanical forces, and pressure are independent of the real-space cutoff and of `g_ewald`;
- `spin/dipole/long` now matches `spin/dipole/cut` and the analytical dipolar energy (including the −2:+1 ratio between parallel and perpendicular configurations);
- the 2-spin attractive case now gives negative pressure (was positive);
- `pppm/dipole/spin` converges to `ewald/dipole/spin`.

A spin port of the dipole RMS force-accuracy test confirms the achieved force error is cutoff-independent and tracks the requested kspace accuracy across `accuracy ∈ {1e-3, 1e-4, 1e-5}` and `cutoff ∈ {3, 5, 7, 10}` (test input posted as a comment below).

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017vJXz7igWW7Rv1hnLgGmgM)_