### PR TITLE
Extend EW3DC triclinic slab correction to pppm/kk + doc clarifications (review of PR #5002)

### DIFF
--- a/doc/src/kspace_modify.rst
+++ b/doc/src/kspace_modify.rst
@@ -459,23 +459,26 @@ boundaries can be set using :doc:`boundary <boundary>` (the slab
 approximation is not needed).  The *slab* keyword with a *volfactor*
 value (the Yeh-Berkowitz EW3DC correction) supports triclinic
 (non-orthogonal) simulation cells for :doc:`kspace_style <kspace_style>`
-*ewald*, *ewald/disp*, *pppm*, and *pppm/cg* (and the OpenMP variants
-that reuse the same slab-correction setup).  Because the slab normal must
-be the Cartesian z axis, only an *xy* tilt is allowed: a triclinic slab
-box with a non-zero *xz* or *yz* tilt is rejected with an error.  The z
-box length must be held fixed for the duration of the run.  Triclinic cells
-are not yet supported with the *slab* keyword for the *pppm/tip4p*,
-*pppm/stagger*, *esp*, *pppm/gpu*, *pppm/intel*, or *pppm/kk* styles, nor
-for the *slab nozforce* and *slab ew2d* options.  The slab correction
-has also been extended to point dipole interactions :ref:`(Klapp)
-<Klapp>` in :doc:`kspace_style <kspace_style>` *ewald/disp*,
-*ewald/dipole*, and *pppm/dipole*\ .
+*ewald*, *ewald/disp*, *pppm*, *pppm/cg*, and *pppm/kk* (and the OpenMP
+variants that reuse the same slab-correction setup).  Because the slab
+normal must be the Cartesian z axis, only an *xy* tilt is allowed: a
+triclinic slab box with a non-zero *xz* or *yz* tilt is rejected with an
+error.  The z box length must be held fixed for the duration of the run.
+Triclinic cells are not yet supported with the *slab* keyword for the
+*pppm/tip4p*, *pppm/stagger*, *esp*, *pppm/gpu*, or *pppm/intel* styles,
+nor for the *slab nozforce* and *slab ew2d* options.
+
+The slab correction has also been extended to point dipole interactions
+:ref:`(Klapp) <Klapp>` in :doc:`kspace_style <kspace_style>` *ewald/disp*,
+*ewald/dipole*, and *pppm/dipole*\ .  This dipole slab correction is
+independent of the triclinic support described above and is currently
+limited to orthogonal (non-triclinic) simulation cells.
 
 .. versionchanged:: TBD
 
    The *slab* correction with a *volfactor* value now supports triclinic
-   simulation cells for the *ewald*, *ewald/disp*, *pppm*, and *pppm/cg*
-   styles.
+   simulation cells for the *ewald*, *ewald/disp*, *pppm*, *pppm/cg*, and
+   *pppm/kk* styles.
 
 .. note::
 

--- a/src/KOKKOS/pppm_kokkos.cpp
+++ b/src/KOKKOS/pppm_kokkos.cpp
@@ -147,8 +147,12 @@ void PPPMKokkos<DeviceType>::init()
   if (triclinic != domain->triclinic)
     error->all(FLERR,"Must redefine kspace_style after changing to triclinic box");
 
-  if (domain->triclinic && slabflag)
-    error->all(FLERR,"Cannot (yet) use PPPM with triclinic box and slab correction");
+  if (domain->triclinic && (slabflag == 2 || slabflag == 3))
+    error->all(FLERR,"Triclinic boxes only support the 'kspace_modify slab "
+               "<volfactor>' correction, not 'slab nozforce' or 'slab ew2d'");
+  if (domain->triclinic && slabflag == 1 && (domain->yz != 0.0 || domain->xz != 0.0))
+    error->all(FLERR,"Triclinic slab (EW3DC) correction requires xz = yz = 0 "
+               "(the slab normal must be the z axis); xy tilt is allowed");
   if (domain->dimension == 2)
     error->all(FLERR,"Cannot use PPPM with 2d simulation");
 
@@ -466,11 +470,16 @@ void PPPMKokkos<DeviceType>::setup_triclinic()
   volume = xprd * yprd * zprd_slab;
 
   // use lamda (0-1) coordinates
+  // for the EW3DC slab correction the lamda z grid is extended by
+  // slab_volfactor (vacuum insertion), matching Grid3d::set_zfactor() used in
+  // the grid decomposition.  delzinv maps lamda z in [0,1] onto grid indices
+  // [0,nz_pppm/slab_volfactor]; delvolinv uses the full nz_pppm so the grid
+  // cell volume stays volume/(nx*ny*nz).  slab_volfactor == 1.0 for non-slab.
 
   delxinv = nx_pppm;
   delyinv = ny_pppm;
-  delzinv = nz_pppm;
-  delvolinv = delxinv*delyinv*delzinv/volume;
+  delzinv = nz_pppm/slab_volfactor;
+  delvolinv = delxinv*delyinv*nz_pppm/volume;
 
   // ensure all relevant _kk values are up to date
   delxinv_kk = static_cast<KK_FLOAT>(delxinv);
@@ -712,13 +721,14 @@ void PPPMKokkos<DeviceType>::compute(int eflag, int vflag)
     }
   }
 
+  // convert atoms back from lamda to box coords
+  // must precede slabcorr(), which needs Cartesian z-coordinates
+
+  if (triclinic) domain->lamda2x(atom->nlocal);
+
   // 2d slab correction
 
   if (slabflag == 1) slabcorr();
-
-  // convert atoms back from lamda to box coords
-
-  if (triclinic) domain->lamda2x(atom->nlocal);
 
   if (eflag_atom) {
     k_eatom.template modify<DeviceType>();
@@ -1102,6 +1112,11 @@ void PPPMKokkos<DeviceType>::compute_gf_ik_triclinic()
   tmp[1] = (g_ewald/(MY_PI*ny_pppm)) * pow(-log(EPS_HOC),0.25);
   tmp[2] = (g_ewald/(MY_PI*nz_pppm)) * pow(-log(EPS_HOC),0.25);
   lamda2xT(&tmp[0],&tmp[0]);
+  // EW3DC slab correction: the z grid is extended by slab_volfactor, so the
+  // alias-sum bound in z must use the extended length (lamda2xT only supplies
+  // zprd).  z is non-periodic for slab geometries (xz == yz == 0), so the z
+  // bound decouples.  slab_volfactor == 1.0 for non-slab calculations.
+  if (slabflag == 1) tmp[2] *= slab_volfactor;
   nbx = static_cast<int> (tmp[0]);
   nby = static_cast<int> (tmp[1]);
   nbz = static_cast<int> (tmp[2]);

--- a/src/KOKKOS/pppm_kokkos.h
+++ b/src/KOKKOS/pppm_kokkos.h
@@ -380,6 +380,14 @@ class PPPMKokkos : public PPPM, public KokkosBaseFFT {
     lamda_tmp[1] = h_inv[5]*v[0] + h_inv[1]*v[1];
     lamda_tmp[2] = h_inv[4]*v[0] + h_inv[3]*v[1] + h_inv[2]*v[2];
 
+    // EW3DC slab correction: the reciprocal-space sum is evaluated on a cell
+    // whose z dimension is extended by slab_volfactor (vacuum insertion).  As
+    // z is non-periodic for slab geometries (xz == yz == 0), the z component of
+    // the transformed reciprocal vector simply scales by 1/slab_volfactor.
+    // This is a no-op (slab_volfactor == 1.0) for all non-slab calculations.
+
+    if (slabflag == 1) lamda_tmp[2] /= slab_volfactor;
+
     lamda[0] = lamda_tmp[0];
     lamda[1] = lamda_tmp[1];
     lamda[2] = lamda_tmp[2];

--- a/unittest/force-styles/tests/kspace-pppm_tri_slab.yaml
+++ b/unittest/force-styles/tests/kspace-pppm_tri_slab.yaml
@@ -3,7 +3,7 @@ lammps_version: 30 Mar 2026
 tags: slow
 date_generated: Thu May 28 16:26:48 2026
 epsilon: 7.5e-14
-skip_tests: gpu intel kokkos_omp
+skip_tests: gpu intel
 prerequisites: ! |
   atom full
   pair coul/long


### PR DESCRIPTION
## Summary

This branch addresses the review comments left on upstream **lammps/lammps#5002**
("Support kspace slab correction (EW3DC) for triclinic boxes").

It is based on `claude/lammps-pr-5002-base`, which holds the reconstructed
PR #5002 content, so the diff here is **only the new work** — two commits:

- `Port EW3DC triclinic slab correction to pppm/kk and clarify slab docs`
- `Enable kokkos_omp regression test for pppm/kk triclinic slab`

## Review comments addressed

**1. "This paragraph is confusing … dipole styles support triclinic slab or just general slab?"**
`doc/src/kspace_modify.rst`: the point-dipole slab correction (`ewald/disp`,
`ewald/dipole`, `pppm/dipole`) is now described in its own paragraph and stated
to be *independent of the triclinic support* and limited to orthogonal cells.

**2 & 3. "Why wasn't this ported to pppm/kk … it's just removing an error check, right?"**
Ported the EW3DC triclinic slab correction to the Kokkos PPPM style (`pppm/kk`).
It's not *only* the error check — it needs the same grid/lattice tweaks the CPU
`pppm.cpp` got, mirrored line-for-line:
- relax the `init()` guard (allow `slabflag==1` with `xz==yz==0`; reject
  nozforce/ew2d and xz/yz-tilted triclinic slab boxes);
- extend the lamda z grid by `slab_volfactor` in `setup_triclinic()`
  (`delzinv`, `delvolinv`);
- scale the z alias-sum bound by `slab_volfactor` in `compute_gf_ik_triclinic()`;
- divide the transformed reciprocal z vector by `slab_volfactor` in
  `x2lamdaT_kokkos()`;
- run `slabcorr()` after `lamda2x()` so it sees Cartesian z. `DomainKokkos::lamda2x`
  runs on-device and flags `X_MASK` modified, so this is correct on the device.

### Styles intentionally left unsupported (the technical reasons)
PR #5002 adds explicit guards rejecting triclinic slab for these — they are not
just stale error checks:
- **pppm/gpu** — charge spreading / grid work lives in the `lib/gpu` device
  kernels, which don't carry the `slab_volfactor` grid extension.
- **pppm/intel** — optimized intrinsic grid paths each need the same treatment.
- **pppm/tip4p** — the M-site reconstruction interacts with the coordinate frame
  during the slab dipole computation.

## Testing
Built with the Kokkos **Serial** backend (`-DPKG_KSPACE=on -DPKG_KOKKOS=on
-DKokkos_ENABLE_SERIAL=on`) and ran `test_pair_style` on the triclinic-slab
references:

| YAML | `PairStyle.plain` (CPU) | `PairStyle.kokkos_omp` (`-sf kk`) |
|------|------|------|
| `kspace-pppm_tri` (non-slab, regression) | ✅ OK | ✅ OK |
| `kspace-pppm_tri_slab` (new) | ✅ OK | ✅ OK |

`pppm/kk` (`-sf kk`) reproduces the reference forces on the triclinic xy-tilted
slab box within the KOKKOS tolerance, and the non-slab triclinic case is
unregressed. `gpu`/`intel` remain in `skip_tests` since those styles still reject
triclinic slab boxes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)