### PR TITLE
KOKKOS: extend fix property/atom to ivector/iarray/darray custom types

### DIFF
--- a/src/KOKKOS/atom_kokkos.cpp
+++ b/src/KOKKOS/atom_kokkos.cpp
@@ -118,6 +118,22 @@ AtomKokkos::~AtomKokkos()
 
   memoryKK->destroy_kokkos(k_dvector, dvector);
   dvector = nullptr;
+
+  memoryKK->destroy_kokkos(k_ivector, ivector);
+  ivector = nullptr;
+
+  // views-of-views: destroy each inner DualView (this also nulls the legacy
+  // iarray[i]/darray[i] pointers, so the base Atom destructor skips them), then
+  // release the outer DualView.
+
+  for (int i = 0; i < niarray; i++)
+    memoryKK->destroy_kokkos(k_iarray.view_host()[i].k_view, iarray[i]);
+  k_iarray = tdual_struct_tdual_int_2d_1d();
+
+  for (int i = 0; i < ndarray; i++)
+    memoryKK->destroy_kokkos(k_darray.view_host()[i].k_view, darray[i]);
+  k_darray = tdual_struct_tdual_double_2d_1d();
+
   delete [] fix_prop_atom;
 }
 
@@ -324,7 +340,9 @@ int AtomKokkos::add_custom(const char *name, int flag, int cols, int ghost)
     ivghost = (int *) memory->srealloc(ivghost,nivector * sizeof(int),"atom:ivghost");
     ivghost[index] = ghost;
     ivector = (int **) memory->srealloc(ivector, nivector * sizeof(int *), "atom:ivector");
-    memory->create(ivector[index], nmax, "atom:ivector");
+    this->sync(Device, IVECTOR_MASK);
+    memoryKK->grow_kokkos(k_ivector, ivector, nivector, nmax, "atom:ivector");
+    this->modified(Device, IVECTOR_MASK);
 
   } else if (flag == 1 && cols == 0) {
     index = ndvector;
@@ -346,10 +364,20 @@ int AtomKokkos::add_custom(const char *name, int flag, int cols, int ghost)
     iaghost = (int *) memory->srealloc(iaghost, niarray * sizeof(int), "atom:iaghost");
     iaghost[index] = ghost;
     iarray = (int ***) memory->srealloc(iarray, niarray * sizeof(int **), "atom:iarray");
-    memory->create(iarray[index], nmax, cols, "atom:iarray");
+    iarray[index] = nullptr;
 
     icols = (int *) memory->srealloc(icols, niarray * sizeof(int), "atom:icols");
     icols[index] = cols;
+
+    // grow the outer view-of-views by one inner DualView for this property.
+    // SequentialHostInit is required: the struct elements wrap a DualView
+    // (non-trivial ctor + atomic refcount), so the default parallel host init
+    // would race constructing/copying the inner DualViews.
+    k_iarray.resize(Kokkos::view_alloc(Kokkos::SequentialHostInit), niarray);
+    memoryKK->create_kokkos(k_iarray.view_host()[index].k_view, iarray[index],
+                            nmax, cols, "atom:iarray");
+    k_iarray.modify_host();
+    k_iarray.sync_device();
 
   } else if (flag == 1 && cols) {
     index = ndarray;
@@ -359,10 +387,17 @@ int AtomKokkos::add_custom(const char *name, int flag, int cols, int ghost)
     daghost = (int *) memory->srealloc(daghost, ndarray * sizeof(int), "atom:daghost");
     daghost[index] = ghost;
     darray = (double ***) memory->srealloc(darray, ndarray * sizeof(double **), "atom:darray");
-    memory->create(darray[index], nmax, cols, "atom:darray");
+    darray[index] = nullptr;
 
     dcols = (int *) memory->srealloc(dcols, ndarray * sizeof(int), "atom:dcols");
     dcols[index] = cols;
+
+    // see iarray branch above for why SequentialHostInit is required here
+    k_darray.resize(Kokkos::view_alloc(Kokkos::SequentialHostInit), ndarray);
+    memoryKK->create_kokkos(k_darray.view_host()[index].k_view, darray[index],
+                            nmax, cols, "atom:darray");
+    k_darray.modify_host();
+    k_darray.sync_device();
   }
 
   if (index < 0)
@@ -379,8 +414,13 @@ int AtomKokkos::add_custom(const char *name, int flag, int cols, int ghost)
 
 void AtomKokkos::remove_custom(int index, int flag, int cols)
 {
+  // the per-atom data is Kokkos-managed (k_ivector/k_dvector are contiguous, and
+  // k_iarray/k_darray are views-of-views), so do NOT memory->destroy() it here --
+  // that would free pointers that alias into a Kokkos view.  Just drop the legacy
+  // alias (ivector/dvector) or free the row-pointer array via destroy_kokkos
+  // (iarray/darray); the view data is released when the Atom is destroyed.
+
   if (flag == 0 && cols == 0) {
-    memory->destroy(ivector[index]);
     ivector[index] = nullptr;
     delete[] ivname[index];
     ivname[index] = nullptr;
@@ -391,13 +431,13 @@ void AtomKokkos::remove_custom(int index, int flag, int cols)
     dvname[index] = nullptr;
 
   } else if (flag == 0 && cols) {
-    memory->destroy(iarray[index]);
+    memoryKK->destroy_kokkos(k_iarray.view_host()[index].k_view, iarray[index]);
     iarray[index] = nullptr;
     delete[] ianame[index];
     ianame[index] = nullptr;
 
   } else if (flag == 1 && cols) {
-    memory->destroy(darray[index]);
+    memoryKK->destroy_kokkos(k_darray.view_host()[index].k_view, darray[index]);
     darray[index] = nullptr;
     delete[] daname[index];
     daname[index] = nullptr;

--- a/src/KOKKOS/atom_kokkos.h
+++ b/src/KOKKOS/atom_kokkos.h
@@ -62,6 +62,9 @@ class AtomKokkos : public Atom {
   DAT::ttransform_tagint_2d k_improper_atom1, k_improper_atom2, k_improper_atom3, k_improper_atom4;
 
   DAT::ttransform_kkfloat_2d k_dvector;
+  DAT::tdual_int_2d_lr k_ivector;         // width-1: single contiguous 2D view
+  tdual_struct_tdual_int_2d_1d k_iarray;  // ragged cols: view-of-views
+  tdual_struct_tdual_double_2d_1d k_darray;
 
   // SPIN package
 

--- a/src/KOKKOS/fix_property_atom_kokkos.cpp
+++ b/src/KOKKOS/fix_property_atom_kokkos.cpp
@@ -32,8 +32,15 @@ FixPropertyAtomKokkos::FixPropertyAtomKokkos(LAMMPS *lmp, int narg, char **arg) 
   kokkosable = 1;
 
   dvector_flag = 0;
-  for (int nv = 0; nv < nvalue; nv++)
+  ivector_flag = 0;
+  iarray_flag = 0;
+  darray_flag = 0;
+  for (int nv = 0; nv < nvalue; nv++) {
+    if (styles[nv] == IVEC) ivector_flag = 1;
     if (styles[nv] == DVEC) dvector_flag = 1;
+    if (styles[nv] == IARRAY) iarray_flag = 1;
+    if (styles[nv] == DARRAY) darray_flag = 1;
+  }
 }
 
 /* ---------------------------------------------------------------------- */
@@ -105,7 +112,12 @@ void FixPropertyAtomKokkos::grow_arrays(int nmax)
       size_t nbytes = (nmax - nmax_old) * sizeof(double);
       memset(&atom->heatflow[nmax_old], 0, nbytes);
     } else if (styles[nv] == IVEC) {
-      memory->grow(atom->ivector[index[nv]],nmax,"atom:ivector");
+      // width-1: single contiguous 2D view, grown like k_dvector
+      atomKK->sync(Device,IVECTOR_MASK);
+      atomKK->modified(Device,IVECTOR_MASK);
+      memoryKK->grow_kokkos(atomKK->k_ivector,atom->ivector,atomKK->k_ivector.extent(0),nmax,
+                          "atom:ivector");
+      atomKK->sync(Host,IVECTOR_MASK);
       size_t nbytes = (nmax-nmax_old) * sizeof(int);
       memset(&atom->ivector[index[nv]][nmax_old],0,nbytes);
     } else if (styles[nv] == DVEC) {
@@ -115,13 +127,24 @@ void FixPropertyAtomKokkos::grow_arrays(int nmax)
                           "atom:dvector");
       atomKK->sync(Host,DVECTOR_MASK);
     } else if (styles[nv] == IARRAY) {
-      memory->grow(atom->iarray[index[nv]], nmax, cols[nv], "atom:iarray");
+      // ragged cols: grow this property's inner DualView in the view-of-views
+      int idx = index[nv];
+      auto& inner = atomKK->k_iarray.view_host()[idx].k_view;
+      memoryKK->grow_kokkos(inner, atom->iarray[idx], nmax, cols[nv], "atom:iarray");
       size_t nbytes = (size_t) (nmax - nmax_old) * cols[nv] * sizeof(int);
-      if (nbytes) memset(&atom->iarray[index[nv]][nmax_old][0], 0, nbytes);
+      if (nbytes) memset(&atom->iarray[idx][nmax_old][0], 0, nbytes);
+      // re-sync the outer struct array: growing the inner view changed its
+      // device pointer, which the device-side view-of-views must see
+      atomKK->k_iarray.modify_host();
+      atomKK->k_iarray.sync_device();
     } else if (styles[nv] == DARRAY) {
-      memory->grow(atom->darray[index[nv]], nmax, cols[nv], "atom:darray");
+      int idx = index[nv];
+      auto& inner = atomKK->k_darray.view_host()[idx].k_view;
+      memoryKK->grow_kokkos(inner, atom->darray[idx], nmax, cols[nv], "atom:darray");
       size_t nbytes = (size_t) (nmax - nmax_old) * cols[nv] * sizeof(double);
-      if (nbytes) memset(&atom->darray[index[nv]][nmax_old][0], 0, nbytes);
+      if (nbytes) memset(&atom->darray[idx][nmax_old][0], 0, nbytes);
+      atomKK->k_darray.modify_host();
+      atomKK->k_darray.sync_device();
     }
   }
   nmax_old = nmax;
@@ -136,16 +159,37 @@ void FixPropertyAtomKokkos::sync(ExecutionSpace space, uint64_t mask)
     if (q_flag && (mask & Q_MASK)) atomKK->k_q.sync_device();
     if (rmass_flag && (mask & RMASS_MASK)) {atomKK->k_rmass.sync_device();}
     if (dvector_flag && (mask & DVECTOR_MASK)) atomKK->k_dvector.sync_device();
+    if (ivector_flag && (mask & IVECTOR_MASK)) atomKK->k_ivector.sync_device();
+    if (iarray_flag && (mask & IARRAY_MASK))
+      for (int i = 0; i < atom->niarray; i++)
+        atomKK->k_iarray.view_host()[i].k_view.sync_device();
+    if (darray_flag && (mask & DARRAY_MASK))
+      for (int i = 0; i < atom->ndarray; i++)
+        atomKK->k_darray.view_host()[i].k_view.sync_device();
   } else if (space == Host) {
     if (molecule_flag && (mask & MOLECULE_MASK)) atomKK->k_molecule.sync_host();
     if (q_flag && (mask & Q_MASK)) atomKK->k_q.sync_host();
     if (rmass_flag && (mask & RMASS_MASK)) atomKK->k_rmass.sync_host();
     if (dvector_flag && (mask & DVECTOR_MASK)) atomKK->k_dvector.sync_host();
+    if (ivector_flag && (mask & IVECTOR_MASK)) atomKK->k_ivector.sync_host();
+    if (iarray_flag && (mask & IARRAY_MASK))
+      for (int i = 0; i < atom->niarray; i++)
+        atomKK->k_iarray.view_host()[i].k_view.sync_host();
+    if (darray_flag && (mask & DARRAY_MASK))
+      for (int i = 0; i < atom->ndarray; i++)
+        atomKK->k_darray.view_host()[i].k_view.sync_host();
   } else if (space == HostKK) {
     if (molecule_flag && (mask & MOLECULE_MASK)) atomKK->k_molecule.sync_host();
     if (q_flag && (mask & Q_MASK)) atomKK->k_q.sync_hostkk();
     if (rmass_flag && (mask & RMASS_MASK)) atomKK->k_rmass.sync_hostkk();
     if (dvector_flag && (mask & DVECTOR_MASK)) atomKK->k_dvector.sync_hostkk();
+    if (ivector_flag && (mask & IVECTOR_MASK)) atomKK->k_ivector.sync_host();
+    if (iarray_flag && (mask & IARRAY_MASK))
+      for (int i = 0; i < atom->niarray; i++)
+        atomKK->k_iarray.view_host()[i].k_view.sync_host();
+    if (darray_flag && (mask & DARRAY_MASK))
+      for (int i = 0; i < atom->ndarray; i++)
+        atomKK->k_darray.view_host()[i].k_view.sync_host();
   }
 }
 
@@ -162,6 +206,18 @@ void FixPropertyAtomKokkos::sync_pinned(ExecutionSpace space, uint64_t mask, int
       atomKK->avecKK->perform_pinned_copy_transform<DAT::ttransform_kkfloat_1d>(atomKK->k_rmass,space,async_flag);
     if ((mask & DVECTOR_MASK) && atomKK->k_dvector.need_sync_device())
       atomKK->avecKK->perform_pinned_copy_transform<DAT::ttransform_kkfloat_2d>(atomKK->k_dvector,space,async_flag);
+    if ((mask & IVECTOR_MASK) && atomKK->k_ivector.need_sync_device())
+      atomKK->avecKK->perform_pinned_copy<DAT::tdual_int_2d_lr>(atomKK->k_ivector,space,async_flag);
+    if (mask & IARRAY_MASK)
+      for (int i = 0; i < atom->niarray; i++)
+        if (atomKK->k_iarray.view_host()[i].k_view.need_sync_device())
+          atomKK->avecKK->perform_pinned_copy<DAT::tdual_int_2d_lr>(
+              atomKK->k_iarray.view_host()[i].k_view, space, async_flag);
+    if (mask & DARRAY_MASK)
+      for (int i = 0; i < atom->ndarray; i++)
+        if (atomKK->k_darray.view_host()[i].k_view.need_sync_device())
+          atomKK->avecKK->perform_pinned_copy<DAT::tdual_double_2d_lr>(
+              atomKK->k_darray.view_host()[i].k_view, space, async_flag);
   } else {
     if ((mask & MOLECULE_MASK) && atomKK->k_molecule.need_sync_host())
       atomKK->avecKK->perform_pinned_copy<DAT::tdual_tagint_1d>(atomKK->k_molecule,space,async_flag);
@@ -171,6 +227,18 @@ void FixPropertyAtomKokkos::sync_pinned(ExecutionSpace space, uint64_t mask, int
       atomKK->avecKK->perform_pinned_copy_transform<DAT::ttransform_kkfloat_1d>(atomKK->k_rmass,space,async_flag);
     if ((mask & DVECTOR_MASK) && atomKK->k_dvector.need_sync_host())
       atomKK->avecKK->perform_pinned_copy_transform<DAT::ttransform_kkfloat_2d>(atomKK->k_dvector,space,async_flag);
+    if ((mask & IVECTOR_MASK) && atomKK->k_ivector.need_sync_host())
+      atomKK->avecKK->perform_pinned_copy<DAT::tdual_int_2d_lr>(atomKK->k_ivector,space,async_flag);
+    if (mask & IARRAY_MASK)
+      for (int i = 0; i < atom->niarray; i++)
+        if (atomKK->k_iarray.view_host()[i].k_view.need_sync_host())
+          atomKK->avecKK->perform_pinned_copy<DAT::tdual_int_2d_lr>(
+              atomKK->k_iarray.view_host()[i].k_view, space, async_flag);
+    if (mask & DARRAY_MASK)
+      for (int i = 0; i < atom->ndarray; i++)
+        if (atomKK->k_darray.view_host()[i].k_view.need_sync_host())
+          atomKK->avecKK->perform_pinned_copy<DAT::tdual_double_2d_lr>(
+              atomKK->k_darray.view_host()[i].k_view, space, async_flag);
   }
 }
 
@@ -183,15 +251,36 @@ void FixPropertyAtomKokkos::modified(ExecutionSpace space, uint64_t mask)
     if (q_flag && (mask & Q_MASK)) atomKK->k_q.modify_device();
     if (rmass_flag && (mask & RMASS_MASK)) atomKK->k_rmass.modify_device();
     if (dvector_flag && (mask & DVECTOR_MASK)) atomKK->k_dvector.modify_device();
+    if (ivector_flag && (mask & IVECTOR_MASK)) atomKK->k_ivector.modify_device();
+    if (iarray_flag && (mask & IARRAY_MASK))
+      for (int i = 0; i < atom->niarray; i++)
+        atomKK->k_iarray.view_host()[i].k_view.modify_device();
+    if (darray_flag && (mask & DARRAY_MASK))
+      for (int i = 0; i < atom->ndarray; i++)
+        atomKK->k_darray.view_host()[i].k_view.modify_device();
   } else if (space == Host) {
     if (molecule_flag && (mask & MOLECULE_MASK)) atomKK->k_molecule.modify_host();
     if (q_flag && (mask & Q_MASK)) atomKK->k_q.modify_host();
     if (rmass_flag && (mask & RMASS_MASK)) atomKK->k_rmass.modify_host();
     if (dvector_flag && (mask & DVECTOR_MASK)) atomKK->k_dvector.modify_host();
+    if (ivector_flag && (mask & IVECTOR_MASK)) atomKK->k_ivector.modify_host();
+    if (iarray_flag && (mask & IARRAY_MASK))
+      for (int i = 0; i < atom->niarray; i++)
+        atomKK->k_iarray.view_host()[i].k_view.modify_host();
+    if (darray_flag && (mask & DARRAY_MASK))
+      for (int i = 0; i < atom->ndarray; i++)
+        atomKK->k_darray.view_host()[i].k_view.modify_host();
   } else if (space == HostKK) {
     if (molecule_flag && (mask & MOLECULE_MASK)) atomKK->k_molecule.modify_host();
     if (q_flag && (mask & Q_MASK)) atomKK->k_q.modify_hostkk();
     if (rmass_flag && (mask & RMASS_MASK)) atomKK->k_rmass.modify_hostkk();
     if (dvector_flag && (mask & DVECTOR_MASK)) atomKK->k_dvector.modify_hostkk();
+    if (ivector_flag && (mask & IVECTOR_MASK)) atomKK->k_ivector.modify_host();
+    if (iarray_flag && (mask & IARRAY_MASK))
+      for (int i = 0; i < atom->niarray; i++)
+        atomKK->k_iarray.view_host()[i].k_view.modify_host();
+    if (darray_flag && (mask & DARRAY_MASK))
+      for (int i = 0; i < atom->ndarray; i++)
+        atomKK->k_darray.view_host()[i].k_view.modify_host();
   }
 }

--- a/src/KOKKOS/fix_property_atom_kokkos.h
+++ b/src/KOKKOS/fix_property_atom_kokkos.h
@@ -39,6 +39,9 @@ class FixPropertyAtomKokkos : public FixPropertyAtom {
 
  private:
   int dvector_flag;
+  int ivector_flag;
+  int iarray_flag;
+  int darray_flag;
 };
 
 }

--- a/src/KOKKOS/kokkos_type.h
+++ b/src/KOKKOS/kokkos_type.h
@@ -1369,6 +1369,29 @@ typedef tdual_neighbors_2d_lr::t_host_const_randomread t_neighbors_2d_lr_randomr
 typedef struct ArrayTypes<LMPDeviceType> DAT;
 typedef struct ArrayTypes<LMPHostType> HAT;
 
+// View-of-views pattern (used by fix property/atom for the per-atom custom
+// iarray/darray arrays, which are "ragged" -- each property has its own column
+// count, so they cannot be packed into a single rectangular view).  Each struct
+// wraps one inner DualView, and an outer DualView<struct*, ...> holds a
+// dynamically-sized list of them that is accessible on the device.  The custom
+// ivector/dvector are width-1 and instead use a single contiguous 2D view.
+
+namespace LAMMPS_NS {
+
+  struct struct_tdual_int_2d {
+    DAT::tdual_int_2d_lr k_view;
+  };
+  typedef Kokkos::DualView<struct_tdual_int_2d*, Kokkos::LayoutRight, LMPDeviceType>
+    tdual_struct_tdual_int_2d_1d;
+
+  struct struct_tdual_double_2d {
+    DAT::tdual_double_2d_lr k_view;
+  };
+  typedef Kokkos::DualView<struct_tdual_double_2d*, Kokkos::LayoutRight, LMPDeviceType>
+    tdual_struct_tdual_double_2d_1d;
+
+}
+
 
 template<class DeviceType, class BufferView, class DualView>
 void buffer_view(BufferView &buf, DualView &view,

--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -321,7 +321,8 @@ Atom::~Atom()
 
   for (int i = 0; i < nivector; i++) {
     delete[] ivname[i];
-    memory->destroy(ivector[i]);
+    if (ivector) // (needed for Kokkos)
+      memory->destroy(ivector[i]);
   }
   for (int i = 0; i < ndvector; i++) {
     delete[] dvname[i];

--- a/src/atom_masks.h
+++ b/src/atom_masks.h
@@ -74,4 +74,10 @@
 #define TORQUE_MASK    0x0000002000000000
 #define ANGMOM_MASK    0x0000004000000000
 
+// custom per-atom arrays (fix property/atom)
+
+#define IVECTOR_MASK   0x0000008000000000
+#define IARRAY_MASK    0x0000010000000000
+#define DARRAY_MASK    0x0000020000000000
+
 #endif


### PR DESCRIPTION
PR #4690 added property/atom/kk but only made the DVEC custom type
device-resident (a single contiguous 2D view k_dvector). This extends
Kokkos support to the remaining custom types, choosing storage by shape:

  - ivector: width-1, so a single contiguous 2D view k_ivector, mirroring
    k_dvector (dvector must stay contiguous because fix rx/kk indexes
    dvector(ispecies,i) across many properties in device kernels).
  - iarray/darray: each property has its own column count, so the set is
    ragged and cannot be one rectangular view. These use the SPARTA
    "views of views" pattern -- an outer DualView<struct{inner DualView}*>
    that holds a dynamically-sized, device-accessible list of inner views.

This avoids a std::vector<DualView> container entirely. The outer views are
resized with Kokkos::view_alloc(Kokkos::SequentialHostInit) because the
struct elements wrap a DualView (non-trivial ctor + atomic refcount), so the
default parallel host init would race on the inner reference counts.

AtomKokkos::add_custom/remove_custom and ~AtomKokkos manage the new views;
remove_custom no longer memory->destroy()s the now-Kokkos-managed data (which
would free pointers aliasing into a view), and the base Atom destructor gets
an "if (ivector)" guard mirroring the existing dvector one.

Verified (KOKKOS Serial + MISC + DPD-REACT): all four custom types
round-trip under -sf kk matching the host baseline, survive atom migration
and write_restart/read_restart, and are valgrind-clean (no invalid frees,
0 bytes lost).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016TFqXe4NfXoRh2D1NLNTtS