### PR TITLE
KOKKOS: device-aware extract_atom, composed with custom-on-device

### DIFF
--- a/src/KOKKOS/atom_kokkos.cpp
+++ b/src/KOKKOS/atom_kokkos.cpp
@@ -118,6 +118,22 @@ AtomKokkos::~AtomKokkos()
 
   memoryKK->destroy_kokkos(k_dvector, dvector);
   dvector = nullptr;
+
+  memoryKK->destroy_kokkos(k_ivector, ivector);
+  ivector = nullptr;
+
+  // views-of-views: destroy each inner DualView (this also nulls the legacy
+  // iarray[i]/darray[i] pointers, so the base Atom destructor skips them), then
+  // release the outer DualView.
+
+  for (int i = 0; i < niarray; i++)
+    memoryKK->destroy_kokkos(k_iarray.view_host()[i].k_view, iarray[i]);
+  k_iarray = tdual_struct_tdual_int_2d_1d();
+
+  for (int i = 0; i < ndarray; i++)
+    memoryKK->destroy_kokkos(k_darray.view_host()[i].k_view, darray[i]);
+  k_darray = tdual_struct_tdual_double_2d_1d();
+
   delete [] fix_prop_atom;
 }
 
@@ -324,7 +340,9 @@ int AtomKokkos::add_custom(const char *name, int flag, int cols, int ghost)
     ivghost = (int *) memory->srealloc(ivghost,nivector * sizeof(int),"atom:ivghost");
     ivghost[index] = ghost;
     ivector = (int **) memory->srealloc(ivector, nivector * sizeof(int *), "atom:ivector");
-    memory->create(ivector[index], nmax, "atom:ivector");
+    this->sync(Device, IVECTOR_MASK);
+    memoryKK->grow_kokkos(k_ivector, ivector, nivector, nmax, "atom:ivector");
+    this->modified(Device, IVECTOR_MASK);
 
   } else if (flag == 1 && cols == 0) {
     index = ndvector;
@@ -346,10 +364,20 @@ int AtomKokkos::add_custom(const char *name, int flag, int cols, int ghost)
     iaghost = (int *) memory->srealloc(iaghost, niarray * sizeof(int), "atom:iaghost");
     iaghost[index] = ghost;
     iarray = (int ***) memory->srealloc(iarray, niarray * sizeof(int **), "atom:iarray");
-    memory->create(iarray[index], nmax, cols, "atom:iarray");
+    iarray[index] = nullptr;
 
     icols = (int *) memory->srealloc(icols, niarray * sizeof(int), "atom:icols");
     icols[index] = cols;
+
+    // grow the outer view-of-views by one inner DualView for this property.
+    // SequentialHostInit is required: the struct elements wrap a DualView
+    // (non-trivial ctor + atomic refcount), so the default parallel host init
+    // would race constructing/copying the inner DualViews.
+    k_iarray.resize(Kokkos::view_alloc(Kokkos::SequentialHostInit), niarray);
+    memoryKK->create_kokkos(k_iarray.view_host()[index].k_view, iarray[index],
+                            nmax, cols, "atom:iarray");
+    k_iarray.modify_host();
+    k_iarray.sync_device();
 
   } else if (flag == 1 && cols) {
     index = ndarray;
@@ -359,10 +387,17 @@ int AtomKokkos::add_custom(const char *name, int flag, int cols, int ghost)
     daghost = (int *) memory->srealloc(daghost, ndarray * sizeof(int), "atom:daghost");
     daghost[index] = ghost;
     darray = (double ***) memory->srealloc(darray, ndarray * sizeof(double **), "atom:darray");
-    memory->create(darray[index], nmax, cols, "atom:darray");
+    darray[index] = nullptr;
 
     dcols = (int *) memory->srealloc(dcols, ndarray * sizeof(int), "atom:dcols");
     dcols[index] = cols;
+
+    // see iarray branch above for why SequentialHostInit is required here
+    k_darray.resize(Kokkos::view_alloc(Kokkos::SequentialHostInit), ndarray);
+    memoryKK->create_kokkos(k_darray.view_host()[index].k_view, darray[index],
+                            nmax, cols, "atom:darray");
+    k_darray.modify_host();
+    k_darray.sync_device();
   }
 
   if (index < 0)
@@ -379,8 +414,13 @@ int AtomKokkos::add_custom(const char *name, int flag, int cols, int ghost)
 
 void AtomKokkos::remove_custom(int index, int flag, int cols)
 {
+  // the per-atom data is Kokkos-managed (k_ivector/k_dvector are contiguous, and
+  // k_iarray/k_darray are views-of-views), so do NOT memory->destroy() it here --
+  // that would free pointers that alias into a Kokkos view.  Just drop the legacy
+  // alias (ivector/dvector) or free the row-pointer array via destroy_kokkos
+  // (iarray/darray); the view data is released when the Atom is destroyed.
+
   if (flag == 0 && cols == 0) {
-    memory->destroy(ivector[index]);
     ivector[index] = nullptr;
     delete[] ivname[index];
     ivname[index] = nullptr;
@@ -391,13 +431,13 @@ void AtomKokkos::remove_custom(int index, int flag, int cols)
     dvname[index] = nullptr;
 
   } else if (flag == 0 && cols) {
-    memory->destroy(iarray[index]);
+    memoryKK->destroy_kokkos(k_iarray.view_host()[index].k_view, iarray[index]);
     iarray[index] = nullptr;
     delete[] ianame[index];
     ianame[index] = nullptr;
 
   } else if (flag == 1 && cols) {
-    memory->destroy(darray[index]);
+    memoryKK->destroy_kokkos(k_darray.view_host()[index].k_view, darray[index]);
     darray[index] = nullptr;
     delete[] daname[index];
     daname[index] = nullptr;

--- a/src/KOKKOS/atom_kokkos.cpp
+++ b/src/KOKKOS/atom_kokkos.cpp
@@ -26,6 +26,9 @@
 #include "modify.h"
 #include "fix.h"
 #include "fix_property_atom_kokkos.h"
+#include "utils.h"
+
+#include <map>
 
 using namespace LAMMPS_NS;
 
@@ -442,6 +445,58 @@ void AtomKokkos::remove_custom(int index, int flag, int cols)
     delete[] daname[index];
     daname[index] = nullptr;
   }
+}
+
+/* ----------------------------------------------------------------------
+   return a pointer to a per-atom property by name (see Atom::extract())
+   the KOKKOS version first syncs the requested data from the device to the
+   host, since the host copy is only guaranteed current at output steps and
+   end of run, but extract() may be called at arbitrary times (e.g. from the
+   library interface, Python, or the GUI)
+------------------------------------------------------------------------- */
+
+void *AtomKokkos::extract(const char *name)
+{
+  // map of built-in per-atom property names to their data mask. passing a mask
+  // for a field the current atom style does not own is a harmless no-op, and
+  // sync() itself is a no-op when the host copy is already current.
+
+  static const std::map<std::string, uint64_t> extract_mask = {
+      {"id", TAG_MASK}, {"type", TYPE_MASK}, {"mask", MASK_MASK}, {"image", IMAGE_MASK},
+      {"x", X_MASK}, {"v", V_MASK}, {"f", F_MASK}, {"q", Q_MASK}, {"mu", MU_MASK},
+      {"omega", OMEGA_MASK}, {"angmom", ANGMOM_MASK}, {"torque", TORQUE_MASK},
+      {"radius", RADIUS_MASK}, {"rmass", RMASS_MASK}, {"ellipsoid", ELLIPSOID_MASK},
+      {"molecule", MOLECULE_MASK}, {"nspecial", SPECIAL_MASK}, {"special", SPECIAL_MASK},
+      {"num_bond", BOND_MASK}, {"bond_type", BOND_MASK}, {"bond_atom", BOND_MASK},
+      {"num_angle", ANGLE_MASK}, {"angle_type", ANGLE_MASK},
+      {"angle_atom1", ANGLE_MASK}, {"angle_atom2", ANGLE_MASK}, {"angle_atom3", ANGLE_MASK},
+      {"num_dihedral", DIHEDRAL_MASK}, {"dihedral_type", DIHEDRAL_MASK},
+      {"dihedral_atom1", DIHEDRAL_MASK}, {"dihedral_atom2", DIHEDRAL_MASK},
+      {"dihedral_atom3", DIHEDRAL_MASK}, {"dihedral_atom4", DIHEDRAL_MASK},
+      {"num_improper", IMPROPER_MASK}, {"improper_type", IMPROPER_MASK},
+      {"improper_atom1", IMPROPER_MASK}, {"improper_atom2", IMPROPER_MASK},
+      {"improper_atom3", IMPROPER_MASK}, {"improper_atom4", IMPROPER_MASK},
+      {"sp", SP_MASK}, {"dpdTheta", DPDTHETA_MASK}};
+
+  const auto it = extract_mask.find(name);
+  if (it != extract_mask.end()) {
+    sync(Host, it->second);
+  } else if (utils::strmatch(name, "^[id]2?_")) {
+    // custom per-atom data (fix property/atom). each prefix maps to its own
+    // device-resident storage and mask:
+    //   i_  -> ivector (IVECTOR_MASK)    d_  -> dvector (DVECTOR_MASK)
+    //   i2_ -> iarray  (IARRAY_MASK)     d2_ -> darray  (DARRAY_MASK)
+    const bool dbl = (name[0] == 'd');
+    const bool arr = (name[1] == '2');
+    uint64_t cmask;
+    if (!dbl && !arr) cmask = IVECTOR_MASK;
+    else if (dbl && !arr) cmask = DVECTOR_MASK;
+    else if (!dbl && arr) cmask = IARRAY_MASK;
+    else cmask = DARRAY_MASK;
+    sync(Host, cmask);
+  }
+
+  return Atom::extract(name);
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/KOKKOS/atom_kokkos.h
+++ b/src/KOKKOS/atom_kokkos.h
@@ -62,6 +62,9 @@ class AtomKokkos : public Atom {
   DAT::ttransform_tagint_2d k_improper_atom1, k_improper_atom2, k_improper_atom3, k_improper_atom4;
 
   DAT::ttransform_kkfloat_2d k_dvector;
+  DAT::tdual_int_2d_lr k_ivector;         // width-1: single contiguous 2D view
+  tdual_struct_tdual_int_2d_1d k_iarray;  // ragged cols: view-of-views
+  tdual_struct_tdual_double_2d_1d k_darray;
 
   // SPIN package
 

--- a/src/KOKKOS/atom_kokkos.h
+++ b/src/KOKKOS/atom_kokkos.h
@@ -173,6 +173,7 @@ class AtomKokkos : public Atom {
   void sort() override;
   int add_custom(const char *, int, int, int border = 0) override;
   void remove_custom(int, int, int) override;
+  void *extract(const char *name) override;
   void deallocate_topology() override;
 
   void map_set_device();

--- a/src/KOKKOS/fix_property_atom_kokkos.cpp
+++ b/src/KOKKOS/fix_property_atom_kokkos.cpp
@@ -32,8 +32,15 @@ FixPropertyAtomKokkos::FixPropertyAtomKokkos(LAMMPS *lmp, int narg, char **arg) 
   kokkosable = 1;
 
   dvector_flag = 0;
-  for (int nv = 0; nv < nvalue; nv++)
+  ivector_flag = 0;
+  iarray_flag = 0;
+  darray_flag = 0;
+  for (int nv = 0; nv < nvalue; nv++) {
+    if (styles[nv] == IVEC) ivector_flag = 1;
     if (styles[nv] == DVEC) dvector_flag = 1;
+    if (styles[nv] == IARRAY) iarray_flag = 1;
+    if (styles[nv] == DARRAY) darray_flag = 1;
+  }
 }
 
 /* ---------------------------------------------------------------------- */
@@ -105,7 +112,12 @@ void FixPropertyAtomKokkos::grow_arrays(int nmax)
       size_t nbytes = (nmax - nmax_old) * sizeof(double);
       memset(&atom->heatflow[nmax_old], 0, nbytes);
     } else if (styles[nv] == IVEC) {
-      memory->grow(atom->ivector[index[nv]],nmax,"atom:ivector");
+      // width-1: single contiguous 2D view, grown like k_dvector
+      atomKK->sync(Device,IVECTOR_MASK);
+      atomKK->modified(Device,IVECTOR_MASK);
+      memoryKK->grow_kokkos(atomKK->k_ivector,atom->ivector,atomKK->k_ivector.extent(0),nmax,
+                          "atom:ivector");
+      atomKK->sync(Host,IVECTOR_MASK);
       size_t nbytes = (nmax-nmax_old) * sizeof(int);
       memset(&atom->ivector[index[nv]][nmax_old],0,nbytes);
     } else if (styles[nv] == DVEC) {
@@ -115,13 +127,24 @@ void FixPropertyAtomKokkos::grow_arrays(int nmax)
                           "atom:dvector");
       atomKK->sync(Host,DVECTOR_MASK);
     } else if (styles[nv] == IARRAY) {
-      memory->grow(atom->iarray[index[nv]], nmax, cols[nv], "atom:iarray");
+      // ragged cols: grow this property's inner DualView in the view-of-views
+      int idx = index[nv];
+      auto& inner = atomKK->k_iarray.view_host()[idx].k_view;
+      memoryKK->grow_kokkos(inner, atom->iarray[idx], nmax, cols[nv], "atom:iarray");
       size_t nbytes = (size_t) (nmax - nmax_old) * cols[nv] * sizeof(int);
-      if (nbytes) memset(&atom->iarray[index[nv]][nmax_old][0], 0, nbytes);
+      if (nbytes) memset(&atom->iarray[idx][nmax_old][0], 0, nbytes);
+      // re-sync the outer struct array: growing the inner view changed its
+      // device pointer, which the device-side view-of-views must see
+      atomKK->k_iarray.modify_host();
+      atomKK->k_iarray.sync_device();
     } else if (styles[nv] == DARRAY) {
-      memory->grow(atom->darray[index[nv]], nmax, cols[nv], "atom:darray");
+      int idx = index[nv];
+      auto& inner = atomKK->k_darray.view_host()[idx].k_view;
+      memoryKK->grow_kokkos(inner, atom->darray[idx], nmax, cols[nv], "atom:darray");
       size_t nbytes = (size_t) (nmax - nmax_old) * cols[nv] * sizeof(double);
-      if (nbytes) memset(&atom->darray[index[nv]][nmax_old][0], 0, nbytes);
+      if (nbytes) memset(&atom->darray[idx][nmax_old][0], 0, nbytes);
+      atomKK->k_darray.modify_host();
+      atomKK->k_darray.sync_device();
     }
   }
   nmax_old = nmax;
@@ -136,16 +159,37 @@ void FixPropertyAtomKokkos::sync(ExecutionSpace space, uint64_t mask)
     if (q_flag && (mask & Q_MASK)) atomKK->k_q.sync_device();
     if (rmass_flag && (mask & RMASS_MASK)) {atomKK->k_rmass.sync_device();}
     if (dvector_flag && (mask & DVECTOR_MASK)) atomKK->k_dvector.sync_device();
+    if (ivector_flag && (mask & IVECTOR_MASK)) atomKK->k_ivector.sync_device();
+    if (iarray_flag && (mask & IARRAY_MASK))
+      for (int i = 0; i < atom->niarray; i++)
+        atomKK->k_iarray.view_host()[i].k_view.sync_device();
+    if (darray_flag && (mask & DARRAY_MASK))
+      for (int i = 0; i < atom->ndarray; i++)
+        atomKK->k_darray.view_host()[i].k_view.sync_device();
   } else if (space == Host) {
     if (molecule_flag && (mask & MOLECULE_MASK)) atomKK->k_molecule.sync_host();
     if (q_flag && (mask & Q_MASK)) atomKK->k_q.sync_host();
     if (rmass_flag && (mask & RMASS_MASK)) atomKK->k_rmass.sync_host();
     if (dvector_flag && (mask & DVECTOR_MASK)) atomKK->k_dvector.sync_host();
+    if (ivector_flag && (mask & IVECTOR_MASK)) atomKK->k_ivector.sync_host();
+    if (iarray_flag && (mask & IARRAY_MASK))
+      for (int i = 0; i < atom->niarray; i++)
+        atomKK->k_iarray.view_host()[i].k_view.sync_host();
+    if (darray_flag && (mask & DARRAY_MASK))
+      for (int i = 0; i < atom->ndarray; i++)
+        atomKK->k_darray.view_host()[i].k_view.sync_host();
   } else if (space == HostKK) {
     if (molecule_flag && (mask & MOLECULE_MASK)) atomKK->k_molecule.sync_host();
     if (q_flag && (mask & Q_MASK)) atomKK->k_q.sync_hostkk();
     if (rmass_flag && (mask & RMASS_MASK)) atomKK->k_rmass.sync_hostkk();
     if (dvector_flag && (mask & DVECTOR_MASK)) atomKK->k_dvector.sync_hostkk();
+    if (ivector_flag && (mask & IVECTOR_MASK)) atomKK->k_ivector.sync_host();
+    if (iarray_flag && (mask & IARRAY_MASK))
+      for (int i = 0; i < atom->niarray; i++)
+        atomKK->k_iarray.view_host()[i].k_view.sync_host();
+    if (darray_flag && (mask & DARRAY_MASK))
+      for (int i = 0; i < atom->ndarray; i++)
+        atomKK->k_darray.view_host()[i].k_view.sync_host();
   }
 }
 
@@ -162,6 +206,18 @@ void FixPropertyAtomKokkos::sync_pinned(ExecutionSpace space, uint64_t mask, int
       atomKK->avecKK->perform_pinned_copy_transform<DAT::ttransform_kkfloat_1d>(atomKK->k_rmass,space,async_flag);
     if ((mask & DVECTOR_MASK) && atomKK->k_dvector.need_sync_device())
       atomKK->avecKK->perform_pinned_copy_transform<DAT::ttransform_kkfloat_2d>(atomKK->k_dvector,space,async_flag);
+    if ((mask & IVECTOR_MASK) && atomKK->k_ivector.need_sync_device())
+      atomKK->avecKK->perform_pinned_copy<DAT::tdual_int_2d_lr>(atomKK->k_ivector,space,async_flag);
+    if (mask & IARRAY_MASK)
+      for (int i = 0; i < atom->niarray; i++)
+        if (atomKK->k_iarray.view_host()[i].k_view.need_sync_device())
+          atomKK->avecKK->perform_pinned_copy<DAT::tdual_int_2d_lr>(
+              atomKK->k_iarray.view_host()[i].k_view, space, async_flag);
+    if (mask & DARRAY_MASK)
+      for (int i = 0; i < atom->ndarray; i++)
+        if (atomKK->k_darray.view_host()[i].k_view.need_sync_device())
+          atomKK->avecKK->perform_pinned_copy<DAT::tdual_double_2d_lr>(
+              atomKK->k_darray.view_host()[i].k_view, space, async_flag);
   } else {
     if ((mask & MOLECULE_MASK) && atomKK->k_molecule.need_sync_host())
       atomKK->avecKK->perform_pinned_copy<DAT::tdual_tagint_1d>(atomKK->k_molecule,space,async_flag);
@@ -171,6 +227,18 @@ void FixPropertyAtomKokkos::sync_pinned(ExecutionSpace space, uint64_t mask, int
       atomKK->avecKK->perform_pinned_copy_transform<DAT::ttransform_kkfloat_1d>(atomKK->k_rmass,space,async_flag);
     if ((mask & DVECTOR_MASK) && atomKK->k_dvector.need_sync_host())
       atomKK->avecKK->perform_pinned_copy_transform<DAT::ttransform_kkfloat_2d>(atomKK->k_dvector,space,async_flag);
+    if ((mask & IVECTOR_MASK) && atomKK->k_ivector.need_sync_host())
+      atomKK->avecKK->perform_pinned_copy<DAT::tdual_int_2d_lr>(atomKK->k_ivector,space,async_flag);
+    if (mask & IARRAY_MASK)
+      for (int i = 0; i < atom->niarray; i++)
+        if (atomKK->k_iarray.view_host()[i].k_view.need_sync_host())
+          atomKK->avecKK->perform_pinned_copy<DAT::tdual_int_2d_lr>(
+              atomKK->k_iarray.view_host()[i].k_view, space, async_flag);
+    if (mask & DARRAY_MASK)
+      for (int i = 0; i < atom->ndarray; i++)
+        if (atomKK->k_darray.view_host()[i].k_view.need_sync_host())
+          atomKK->avecKK->perform_pinned_copy<DAT::tdual_double_2d_lr>(
+              atomKK->k_darray.view_host()[i].k_view, space, async_flag);
   }
 }
 
@@ -183,15 +251,36 @@ void FixPropertyAtomKokkos::modified(ExecutionSpace space, uint64_t mask)
     if (q_flag && (mask & Q_MASK)) atomKK->k_q.modify_device();
     if (rmass_flag && (mask & RMASS_MASK)) atomKK->k_rmass.modify_device();
     if (dvector_flag && (mask & DVECTOR_MASK)) atomKK->k_dvector.modify_device();
+    if (ivector_flag && (mask & IVECTOR_MASK)) atomKK->k_ivector.modify_device();
+    if (iarray_flag && (mask & IARRAY_MASK))
+      for (int i = 0; i < atom->niarray; i++)
+        atomKK->k_iarray.view_host()[i].k_view.modify_device();
+    if (darray_flag && (mask & DARRAY_MASK))
+      for (int i = 0; i < atom->ndarray; i++)
+        atomKK->k_darray.view_host()[i].k_view.modify_device();
   } else if (space == Host) {
     if (molecule_flag && (mask & MOLECULE_MASK)) atomKK->k_molecule.modify_host();
     if (q_flag && (mask & Q_MASK)) atomKK->k_q.modify_host();
     if (rmass_flag && (mask & RMASS_MASK)) atomKK->k_rmass.modify_host();
     if (dvector_flag && (mask & DVECTOR_MASK)) atomKK->k_dvector.modify_host();
+    if (ivector_flag && (mask & IVECTOR_MASK)) atomKK->k_ivector.modify_host();
+    if (iarray_flag && (mask & IARRAY_MASK))
+      for (int i = 0; i < atom->niarray; i++)
+        atomKK->k_iarray.view_host()[i].k_view.modify_host();
+    if (darray_flag && (mask & DARRAY_MASK))
+      for (int i = 0; i < atom->ndarray; i++)
+        atomKK->k_darray.view_host()[i].k_view.modify_host();
   } else if (space == HostKK) {
     if (molecule_flag && (mask & MOLECULE_MASK)) atomKK->k_molecule.modify_host();
     if (q_flag && (mask & Q_MASK)) atomKK->k_q.modify_hostkk();
     if (rmass_flag && (mask & RMASS_MASK)) atomKK->k_rmass.modify_hostkk();
     if (dvector_flag && (mask & DVECTOR_MASK)) atomKK->k_dvector.modify_hostkk();
+    if (ivector_flag && (mask & IVECTOR_MASK)) atomKK->k_ivector.modify_host();
+    if (iarray_flag && (mask & IARRAY_MASK))
+      for (int i = 0; i < atom->niarray; i++)
+        atomKK->k_iarray.view_host()[i].k_view.modify_host();
+    if (darray_flag && (mask & DARRAY_MASK))
+      for (int i = 0; i < atom->ndarray; i++)
+        atomKK->k_darray.view_host()[i].k_view.modify_host();
   }
 }

--- a/src/KOKKOS/fix_property_atom_kokkos.h
+++ b/src/KOKKOS/fix_property_atom_kokkos.h
@@ -39,6 +39,9 @@ class FixPropertyAtomKokkos : public FixPropertyAtom {
 
  private:
   int dvector_flag;
+  int ivector_flag;
+  int iarray_flag;
+  int darray_flag;
 };
 
 }

--- a/src/KOKKOS/kokkos_type.h
+++ b/src/KOKKOS/kokkos_type.h
@@ -1369,6 +1369,29 @@ typedef tdual_neighbors_2d_lr::t_host_const_randomread t_neighbors_2d_lr_randomr
 typedef struct ArrayTypes<LMPDeviceType> DAT;
 typedef struct ArrayTypes<LMPHostType> HAT;
 
+// View-of-views pattern (used by fix property/atom for the per-atom custom
+// iarray/darray arrays, which are "ragged" -- each property has its own column
+// count, so they cannot be packed into a single rectangular view).  Each struct
+// wraps one inner DualView, and an outer DualView<struct*, ...> holds a
+// dynamically-sized list of them that is accessible on the device.  The custom
+// ivector/dvector are width-1 and instead use a single contiguous 2D view.
+
+namespace LAMMPS_NS {
+
+  struct struct_tdual_int_2d {
+    DAT::tdual_int_2d_lr k_view;
+  };
+  typedef Kokkos::DualView<struct_tdual_int_2d*, Kokkos::LayoutRight, LMPDeviceType>
+    tdual_struct_tdual_int_2d_1d;
+
+  struct struct_tdual_double_2d {
+    DAT::tdual_double_2d_lr k_view;
+  };
+  typedef Kokkos::DualView<struct_tdual_double_2d*, Kokkos::LayoutRight, LMPDeviceType>
+    tdual_struct_tdual_double_2d_1d;
+
+}
+
 
 template<class DeviceType, class BufferView, class DualView>
 void buffer_view(BufferView &buf, DualView &view,

--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -321,7 +321,8 @@ Atom::~Atom()
 
   for (int i = 0; i < nivector; i++) {
     delete[] ivname[i];
-    memory->destroy(ivector[i]);
+    if (ivector) // (needed for Kokkos)
+      memory->destroy(ivector[i]);
   }
   for (int i = 0; i < ndvector; i++) {
     delete[] dvname[i];

--- a/src/atom.h
+++ b/src/atom.h
@@ -384,7 +384,7 @@ class Atom : protected Pointers {
   virtual int add_custom(const char *, int, int, int ghost = 0);
   virtual void remove_custom(int, int, int);
 
-  void *extract(const char *);
+  virtual void *extract(const char *);
   int extract_datatype(const char *);
   int extract_size(const char *, int);
 

--- a/src/atom_masks.h
+++ b/src/atom_masks.h
@@ -74,4 +74,10 @@
 #define TORQUE_MASK    0x0000002000000000
 #define ANGMOM_MASK    0x0000004000000000
 
+// custom per-atom arrays (fix property/atom)
+
+#define IVECTOR_MASK   0x0000008000000000
+#define IARRAY_MASK    0x0000010000000000
+#define DARRAY_MASK    0x0000020000000000
+
 #endif

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -2585,6 +2585,14 @@ A table with supported keywords is included in the documentation of the
    since per-atom data may be re-distributed, re-allocated, and
    re-ordered at every re-neighboring operation.
 
+.. note::
+
+   When using the KOKKOS package on a device (e.g. a GPU), the host copy
+   of the requested per-atom data is synchronized from the device before
+   the pointer is returned, so the data is current even when accessed
+   between output steps.  This sync is a no-op when the host copy is
+   already up to date.
+
 \endverbatim
  *
  * \param  handle  pointer to a previously created LAMMPS instance


### PR DESCRIPTION
## Summary

Makes `lammps_extract_atom()` / `Atom::extract()` device-aware for the KOKKOS package so it returns current host data instead of stale copies when called at arbitrary times (library interface, Python, GUI) — addresses the problem in lammps/lammps#3945.

Because it is based on `develop`, this branch bundles **two pieces** that compose together:

1. **Port all custom per-atom data to device** (from the `claude/lammps-pr-4690-review-67u6zp` work / lammps/lammps#4690): `ivector`/`iarray`/`darray` become device-resident DualViews with their own masks `IVECTOR_MASK` / `IARRAY_MASK` / `DARRAY_MASK` (joining the existing `DVECTOR_MASK`), wired through `fix property/atom` sync/modified/sync_pinned.
2. **Device-aware `extract()`** (the review fix for lammps/lammps#5014): `Atom::extract()` is made `virtual` and overridden in `AtomKokkos` to `sync(Host, ...)` the requested property before delegating to the base implementation.

## Why combined

The original #5014 only synced `DVECTOR_MASK` via a `^d2?_` regex. That is wrong in two ways once custom data is on the device:
- `d2_` (darray) matched but synced the *wrong* mask (`DVECTOR_MASK`, which is dvector), and
- `i_` / `i2_` were never synced at all → stale data after #4690.

This PR's fallback matches the full `^[id]2?_` pattern (same as `Atom::extract`) and decodes the prefix to the correct mask:

```
i_  -> IVECTOR_MASK    d_  -> DVECTOR_MASK
i2_ -> IARRAY_MASK     d2_ -> DARRAY_MASK
```

Precise per-property syncing is kept (rather than a blanket `ALL_MASK`) so repeated/polled `extract_atom` calls don't over-copy; `sync` is a no-op when the host copy is already current.

## Testing

Built with KOKKOS **Serial** (GCC 13.3, C++20) — clean compile.

- LJ system with `fix property/atom i_ d_ i2_ d2_ ghost yes` runs cleanly; `lmp` exits 0.
- Per-atom dump of all four custom types under KOKKOS is **byte-identical** to the non-KOKKOS path.
- A library-API driver calling `lammps_extract_atom()` on `i_`/`d_`/`i2_`/`d2_` (which routes through the new `AtomKokkos::extract`) returns correct values: `PASS (0 mismatches)` over all atoms.

Note: with the Serial backend host and device share memory, so the device→host sync is structurally a no-op — these tests confirm correctness and no regression, but the stale-data fix itself can only be exercised on a real device backend (CUDA/HIP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WvmBeBBxFmEGbgGo4eDZxu)_