### PR TITLE
KOKKOS PACE: fall back to global scratch memory when shared memory is exceeded

### DIFF
--- a/doc/src/pair_pace.rst
+++ b/doc/src/pair_pace.rst
@@ -24,10 +24,14 @@ Syntax
 
   .. parsed-literal::
 
-     keyword = *product* or *recursive* or *chunksize*
+     keyword = *product* or *recursive* or *chunksize* or *neigh*
        *product* = use product algorithm for basis functions
        *recursive* = use recursive algorithm for basis functions
        *chunksize* value = number of atoms in each pass
+       *neigh* value = *auto* or *shared* or *global*
+         *auto* = automatically select team scratch memory level for the neighbor list build (default)
+         *shared* = force on-chip (level 0) shared memory scratch
+         *global* = force global (level 1) memory scratch
 
 .. code-block:: LAMMPS
 
@@ -89,6 +93,29 @@ atomic cluster expansion and is used to avoid running out of memory.
 For example if there are 8192 atoms in the simulation and the
 *chunksize* is set to 4096, the ACE calculation will be broken up into
 two passes (running on a single GPU).
+
+.. versionadded:: TBD
+
+The keyword *neigh* is only applicable when using the pair style *pace*
+or *pace/extrapolation* with the KOKKOS package on GPUs and is ignored
+otherwise.  It controls which level of Kokkos team scratch memory is
+used to build the short neighbor list.  Level 0 is fast on-chip shared
+memory, but it is a limited resource that can be exceeded when atoms
+have many neighbors and/or when there are many atomic species, which
+would otherwise abort the run with an error such as "Requested too much
+scratch memory on level 0".  Level 1 is (much larger) global memory,
+which avoids the limit at the cost of slower access.
+
+With the default value *auto*, the pair style queries the amount of
+shared memory available on the device (rather than assuming a fixed
+value such as 48 KiB, so that larger limits available in newer versions
+of the Kokkos library are used automatically) and transparently falls
+back to level 1 when the request does not fit into level 0, printing a
+warning the first time this happens.  The value *shared* forces the use
+of level 0 (on-chip) scratch memory, and *global* forces the use of
+level 1 (global) scratch memory; the latter can be used to silence the
+fallback warning or to force global memory when the automatic heuristic
+is too conservative.
 
 Extrapolation grade
 """""""""""""""""""

--- a/src/KOKKOS/pair_pace_extrapolation_kokkos.cpp
+++ b/src/KOKKOS/pair_pace_extrapolation_kokkos.cpp
@@ -28,6 +28,7 @@
 #include "memory_kokkos.h"
 #include "neighbor_kokkos.h"
 #include "neigh_request.h"
+#include "utils.h"
 
 #include "ace-evaluator/ace_version.h"
 #include "ace-evaluator/ace_radial.h"
@@ -64,6 +65,10 @@ PairPACEExtrapolationKokkos<DeviceType>::PairPACEExtrapolationKokkos(LAMMPS *lmp
   datamask_modify = EMPTY_MASK;
 
   host_flag = (execution_space == HostKK);
+
+  neigh_scratch_request = NEIGH_SCRATCH_AUTO;
+  neigh_scratch_level = 0;
+  neigh_scratch_warned = 0;
 }
 
 /* ----------------------------------------------------------------------
@@ -497,6 +502,76 @@ double PairPACEExtrapolationKokkos<DeviceType>::init_one(int i, int j)
 }
 
 /* ----------------------------------------------------------------------
+   global settings
+------------------------------------------------------------------------- */
+
+template<class DeviceType>
+void PairPACEExtrapolationKokkos<DeviceType>::settings(int narg, char **arg)
+{
+  // intercept the KOKKOS-only "neigh" keyword, which selects the team scratch
+  // memory level used to build the short neighbor list, then forward the
+  // remaining keywords to the CPU base class
+
+  auto base_arg = new char*[narg];
+  int base_narg = 0;
+  int iarg = 0;
+  while (iarg < narg) {
+    if (strcmp(arg[iarg], "neigh") == 0) {
+      if (iarg+2 > narg)
+        utils::missing_cmd_args(FLERR, "pair_style pace/extrapolation neigh", error);
+      if (strcmp(arg[iarg+1], "auto") == 0)
+        neigh_scratch_request = NEIGH_SCRATCH_AUTO;
+      else if (strcmp(arg[iarg+1], "shared") == 0)
+        neigh_scratch_request = NEIGH_SCRATCH_SHARED;
+      else if (strcmp(arg[iarg+1], "global") == 0)
+        neigh_scratch_request = NEIGH_SCRATCH_GLOBAL;
+      else
+        error->all(FLERR, "Unknown pair_style pace/extrapolation neigh keyword: {}", arg[iarg+1]);
+      iarg += 2;
+    } else {
+      base_arg[base_narg++] = arg[iarg];
+      iarg++;
+    }
+  }
+
+  PairPACEExtrapolation::settings(base_narg, base_arg);
+
+  delete[] base_arg;
+}
+
+/* ----------------------------------------------------------------------
+   select the team scratch memory level for the ComputeNeigh short neighbor
+   list build; falls back from level 0 (fast on-chip shared memory) to level 1
+   (global memory) when the request does not fit into the available shared
+   memory, unless the user forced a level
+------------------------------------------------------------------------- */
+
+template<class DeviceType>
+int PairPACEExtrapolationKokkos<DeviceType>::neigh_scratch_level_select(int scratch_size, int max_level0)
+{
+  // honor an explicit user request
+  if (neigh_scratch_request == NEIGH_SCRATCH_SHARED) return 0;
+  if (neigh_scratch_request == NEIGH_SCRATCH_GLOBAL) return 1;
+
+  // automatic: use fast level-0 (shared) scratch when it fits, otherwise fall
+  // back to level-1 (global) scratch. max_level0 is queried from Kokkos rather
+  // than hard-coded, so larger shared-memory limits (e.g. the opt-in >48 KiB
+  // shared memory available in newer Kokkos) are used automatically.
+  if (scratch_size <= max_level0) return 0;
+
+  if (!neigh_scratch_warned && comm->me == 0) {
+    error->warning(FLERR,
+      "Pair pace/extrapolation/kk short neighbor list needs {} bytes of team "
+      "scratch memory but only {} bytes of on-chip (level-0) shared memory are "
+      "available; falling back to slower global (level-1) memory. Reduce the "
+      "neighbor count or use the pair_style 'neigh global' keyword to silence "
+      "this warning.", scratch_size, max_level0);
+    neigh_scratch_warned = 1;
+  }
+  return 1;
+}
+
+/* ----------------------------------------------------------------------
    set coeffs for one or more type pairs
 ------------------------------------------------------------------------- */
 
@@ -671,7 +746,16 @@ void PairPACEExtrapolationKokkos<DeviceType>::compute(int eflag_in, int vflag_in
       check_team_size_for<TagPairPACEComputeNeigh>(chunk_size,team_size,vector_length);
       int scratch_size = scratch_size_helper<int>(team_size * maxneigh);
       typename Kokkos::TeamPolicy<DeviceType, TagPairPACEComputeNeigh> policy_neigh(chunk_size,team_size,vector_length);
-      policy_neigh = policy_neigh.set_scratch_size(0, Kokkos::PerTeam(scratch_size));
+
+      // The ComputeNeigh kernel caches the short neighbor list in team scratch
+      // memory. On GPUs level-0 scratch is fast on-chip shared memory but is a
+      // scarce resource: with many neighbors and/or atom types the request can
+      // exceed what the device provides and abort the run (see
+      // https://github.com/lammps/lammps/issues/5063). Query the level-0 limit
+      // from Kokkos (never hard-coded) and transparently fall back to level-1
+      // (global memory) scratch when the request does not fit.
+      neigh_scratch_level = neigh_scratch_level_select(scratch_size, policy_neigh.scratch_size_max(0));
+      policy_neigh = policy_neigh.set_scratch_size(neigh_scratch_level, Kokkos::PerTeam(scratch_size));
       Kokkos::parallel_for("ComputeNeigh",policy_neigh,*this);
     }
 
@@ -830,7 +914,7 @@ void PairPACEExtrapolationKokkos<DeviceType>::operator() (TagPairPACEComputeNeig
   // If it is, inside is assigned to 1, otherwise -1
   const int team_rank = team.team_rank();
   const int scratch_shift = team_rank * maxneigh; // offset into pointer for entire team
-  int* inside = (int*)team.team_shmem().get_shmem(team.team_size() * maxneigh * sizeof(int), 0) + scratch_shift;
+  int* inside = (int*)team.team_shmem().get_shmem(team.team_size() * maxneigh * sizeof(int), neigh_scratch_level) + scratch_shift;
 
   // loop over list of all neighbors within force cutoff
   // distsq[] = distance sq to each

--- a/src/KOKKOS/pair_pace_extrapolation_kokkos.h
+++ b/src/KOKKOS/pair_pace_extrapolation_kokkos.h
@@ -56,6 +56,7 @@ class PairPACEExtrapolationKokkos : public PairPACEExtrapolation {
   ~PairPACEExtrapolationKokkos() override;
 
   void compute(int, int) override;
+  void settings(int, char **) override;
   void coeff(int, char **) override;
   void init_style() override;
   double init_one(int, int) override;
@@ -109,6 +110,19 @@ class PairPACEExtrapolationKokkos : public PairPACEExtrapolation {
  protected:
   int inum, maxneigh, chunk_size, chunk_offset, idx_ms_combs_max, total_num_functions_max, idx_sph_max;
   int host_flag;
+
+  // team scratch memory level used by the ComputeNeigh short neighbor list build:
+  //   NEIGH_SCRATCH_AUTO   - automatically use level 0 (fast on-chip shared
+  //                          memory) when it fits, else fall back to level 1
+  //                          (global memory)
+  //   NEIGH_SCRATCH_SHARED - always use level 0
+  //   NEIGH_SCRATCH_GLOBAL - always use level 1
+  enum { NEIGH_SCRATCH_AUTO = 0, NEIGH_SCRATCH_SHARED, NEIGH_SCRATCH_GLOBAL };
+  int neigh_scratch_request;  // user preference (pair_style "neigh" keyword)
+  int neigh_scratch_level;    // level actually used by ComputeNeigh (0 or 1)
+  int neigh_scratch_warned;   // whether the auto-fallback warning was printed
+
+  int neigh_scratch_level_select(int scratch_size, int max_level0);
 
   int eflag, vflag;
 

--- a/src/KOKKOS/pair_pace_kokkos.cpp
+++ b/src/KOKKOS/pair_pace_kokkos.cpp
@@ -28,6 +28,7 @@
 #include "memory_kokkos.h"
 #include "neighbor_kokkos.h"
 #include "neigh_request.h"
+#include "utils.h"
 
 #include "ace-evaluator/ace_version.h"
 #include "ace-evaluator/ace_radial.h"
@@ -65,6 +66,10 @@ PairPACEKokkos<DeviceType>::PairPACEKokkos(LAMMPS *lmp) : PairPACE(lmp)
   datamask_modify = EMPTY_MASK;
 
   host_flag = (execution_space == HostKK);
+
+  neigh_scratch_request = NEIGH_SCRATCH_AUTO;
+  neigh_scratch_level = 0;
+  neigh_scratch_warned = 0;
 }
 
 /* ----------------------------------------------------------------------
@@ -469,6 +474,76 @@ double PairPACEKokkos<DeviceType>::init_one(int i, int j)
 }
 
 /* ----------------------------------------------------------------------
+   global settings
+------------------------------------------------------------------------- */
+
+template<class DeviceType>
+void PairPACEKokkos<DeviceType>::settings(int narg, char **arg)
+{
+  // intercept the KOKKOS-only "neigh" keyword, which selects the team scratch
+  // memory level used to build the short neighbor list, then forward the
+  // remaining keywords to the CPU base class
+
+  auto base_arg = new char*[narg];
+  int base_narg = 0;
+  int iarg = 0;
+  while (iarg < narg) {
+    if (strcmp(arg[iarg], "neigh") == 0) {
+      if (iarg+2 > narg)
+        utils::missing_cmd_args(FLERR, "pair_style pace neigh", error);
+      if (strcmp(arg[iarg+1], "auto") == 0)
+        neigh_scratch_request = NEIGH_SCRATCH_AUTO;
+      else if (strcmp(arg[iarg+1], "shared") == 0)
+        neigh_scratch_request = NEIGH_SCRATCH_SHARED;
+      else if (strcmp(arg[iarg+1], "global") == 0)
+        neigh_scratch_request = NEIGH_SCRATCH_GLOBAL;
+      else
+        error->all(FLERR, "Unknown pair_style pace neigh keyword: {}", arg[iarg+1]);
+      iarg += 2;
+    } else {
+      base_arg[base_narg++] = arg[iarg];
+      iarg++;
+    }
+  }
+
+  PairPACE::settings(base_narg, base_arg);
+
+  delete[] base_arg;
+}
+
+/* ----------------------------------------------------------------------
+   select the team scratch memory level for the ComputeNeigh short neighbor
+   list build; falls back from level 0 (fast on-chip shared memory) to level 1
+   (global memory) when the request does not fit into the available shared
+   memory, unless the user forced a level
+------------------------------------------------------------------------- */
+
+template<class DeviceType>
+int PairPACEKokkos<DeviceType>::neigh_scratch_level_select(int scratch_size, int max_level0)
+{
+  // honor an explicit user request
+  if (neigh_scratch_request == NEIGH_SCRATCH_SHARED) return 0;
+  if (neigh_scratch_request == NEIGH_SCRATCH_GLOBAL) return 1;
+
+  // automatic: use fast level-0 (shared) scratch when it fits, otherwise fall
+  // back to level-1 (global) scratch. max_level0 is queried from Kokkos rather
+  // than hard-coded, so larger shared-memory limits (e.g. the opt-in >48 KiB
+  // shared memory available in newer Kokkos) are used automatically.
+  if (scratch_size <= max_level0) return 0;
+
+  if (!neigh_scratch_warned && comm->me == 0) {
+    error->warning(FLERR,
+      "Pair pace/kk short neighbor list needs {} bytes of team scratch memory "
+      "but only {} bytes of on-chip (level-0) shared memory are available; "
+      "falling back to slower global (level-1) memory. Reduce the neighbor "
+      "count or use the pair_style 'neigh global' keyword to silence this "
+      "warning.", scratch_size, max_level0);
+    neigh_scratch_warned = 1;
+  }
+  return 1;
+}
+
+/* ----------------------------------------------------------------------
    set coeffs for one or more type pairs
 ------------------------------------------------------------------------- */
 
@@ -631,7 +706,16 @@ void PairPACEKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
       check_team_size_for<TagPairPACEComputeNeigh>(chunk_size,team_size,vector_length);
       int scratch_size = scratch_size_helper<int>(team_size * maxneigh);
       typename Kokkos::TeamPolicy<DeviceType, TagPairPACEComputeNeigh> policy_neigh(chunk_size,team_size,vector_length);
-      policy_neigh = policy_neigh.set_scratch_size(0, Kokkos::PerTeam(scratch_size));
+
+      // The ComputeNeigh kernel caches the short neighbor list in team scratch
+      // memory. On GPUs level-0 scratch is fast on-chip shared memory but is a
+      // scarce resource: with many neighbors and/or atom types the request can
+      // exceed what the device provides and abort the run (see
+      // https://github.com/lammps/lammps/issues/5063). Query the level-0 limit
+      // from Kokkos (never hard-coded) and transparently fall back to level-1
+      // (global memory) scratch when the request does not fit.
+      neigh_scratch_level = neigh_scratch_level_select(scratch_size, policy_neigh.scratch_size_max(0));
+      policy_neigh = policy_neigh.set_scratch_size(neigh_scratch_level, Kokkos::PerTeam(scratch_size));
       Kokkos::parallel_for("ComputeNeigh",policy_neigh,*this);
     }
 
@@ -776,7 +860,7 @@ void PairPACEKokkos<DeviceType>::operator() (TagPairPACEComputeNeigh,const typen
   // If it is, inside is assigned to 1, otherwise -1
   const int team_rank = team.team_rank();
   const int scratch_shift = team_rank * maxneigh; // offset into pointer for entire team
-  int* inside = (int*)team.team_shmem().get_shmem(team.team_size() * maxneigh * sizeof(int), 0) + scratch_shift;
+  int* inside = (int*)team.team_shmem().get_shmem(team.team_size() * maxneigh * sizeof(int), neigh_scratch_level) + scratch_shift;
 
   // loop over list of all neighbors within force cutoff
   // distsq[] = distance sq to each

--- a/src/KOKKOS/pair_pace_kokkos.h
+++ b/src/KOKKOS/pair_pace_kokkos.h
@@ -55,6 +55,7 @@ class PairPACEKokkos : public PairPACE {
   ~PairPACEKokkos() override;
 
   void compute(int, int) override;
+  void settings(int, char **) override;
   void coeff(int, char **) override;
   void init_style() override;
   double init_one(int, int) override;
@@ -104,6 +105,19 @@ class PairPACEKokkos : public PairPACE {
  protected:
   int inum, maxneigh, chunk_size, chunk_offset, idx_ms_combs_max, idx_sph_max;
   int host_flag;
+
+  // team scratch memory level used by the ComputeNeigh short neighbor list build:
+  //   NEIGH_SCRATCH_AUTO   - automatically use level 0 (fast on-chip shared
+  //                          memory) when it fits, else fall back to level 1
+  //                          (global memory)
+  //   NEIGH_SCRATCH_SHARED - always use level 0
+  //   NEIGH_SCRATCH_GLOBAL - always use level 1
+  enum { NEIGH_SCRATCH_AUTO = 0, NEIGH_SCRATCH_SHARED, NEIGH_SCRATCH_GLOBAL };
+  int neigh_scratch_request;  // user preference (pair_style "neigh" keyword)
+  int neigh_scratch_level;    // level actually used by ComputeNeigh (0 or 1)
+  int neigh_scratch_warned;   // whether the auto-fallback warning was printed
+
+  int neigh_scratch_level_select(int scratch_size, int max_level0);
 
   int eflag, vflag;
 


### PR DESCRIPTION
**Summary**

The `ComputeNeigh` kernel in `pair_style pace/kk` and `pace/extrapolation/kk` caches the short neighbor list in level-0 (on-chip shared) team scratch memory, sized `team_size * maxneigh * sizeof(int)`. On GPUs this is a scarce resource, so runs with many neighbors and/or many atomic species abort with `Requested too much scratch memory on level 0` (CUDA) or `could not find a valid team size` (HIP), even though nothing about the hardware makes the calculation impossible.

This pull request queries the maximum available level-0 scratch from Kokkos via `TeamPolicy::scratch_size_max(0)` and transparently falls back to level-1 (global memory) scratch when the request does not fit, printing a warning the first time it happens. The limit is queried rather than hard-coded (e.g. 48 KiB), so larger shared-memory limits — such as the opt-in >48 KiB shared memory for CUDA added in kokkos/kokkos#9012 — are picked up automatically once that lands in a bundled Kokkos version, with no further changes needed here.

A new `neigh` keyword (`auto` | `shared` | `global`) lets the user override the automatic choice.

**Related Issue(s)**

fixes lammps/lammps#5063

See also the related user report: https://matsci.org/t/kokkos-2080-gpu-runs-out-of-shared-memory-with-3-atomic-species/67287

**Author(s)**

Stan Moore, Sandia National Laboratories (stanmoore1@gmail.com)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Artificial Intelligence (AI) Tools Usage**

AI tools were used for this contribution. Claude Code (Anthropic) generated the code changes in `src/KOKKOS/pair_pace_kokkos.{cpp,h}` and `src/KOKKOS/pair_pace_extrapolation_kokkos.{cpp,h}`, along with the corresponding documentation updates in `doc/src/pair_pace.rst`, working from a human-provided problem description and design direction (query the limit from the Kokkos API rather than hard-coding it, and provide a user-facing override keyword). The changes were reviewed and verified by a human before submission.

**Backward Compatibility**

Backward compatible. The default `neigh auto` setting preserves the existing behavior of using level-0 shared memory whenever the request fits, which is the case for all inputs that run successfully today; the fallback only engages where the run would previously have aborted. The `neigh` keyword is optional and new. Note that, consistent with the existing `chunksize` keyword, `neigh` is only accepted by the KOKKOS variants of the styles.

**Implementation Notes**

The scratch level is selected per launch in `compute()` and stored in a member that the kernel reads when calling `team.team_shmem().get_shmem(..., neigh_scratch_level)`, so the same kernel serves both levels without duplication.

The comparison uses `TeamPolicy::scratch_size_max(0)`, which is backend-agnostic and device-queried (`sharedMemPerBlock` on CUDA/HIP). It is also strictly more conservative than the check Kokkos performs at launch: `scratch_size_max(0)` reserves for the maximum possible team size (1024), while the actual launch-time check only reserves for the real team size. The fallback therefore always engages before Kokkos would throw, never after.

Both the base and extrapolation styles were fixed together, since they share this code shape.

Verification: built with CMake (KOKKOS + ML-PACE, Serial backend) with no errors or warnings. An fcc-Cu ACE benchmark was run for 100 MD steps in all three modes — `neigh auto`, `neigh shared`, `neigh global` — and all three produce bit-for-bit identical energies, temperatures, and pressures across the full trajectory, confirming that the level-1 path computes the same result as the level-0 path. Keyword handling was also exercised: an invalid value errors cleanly, `chunksize` and `neigh` combine in either order, and the non-KOKKOS `pace` style correctly rejects the KOKKOS-only keyword. All `make check-*` style targets pass.

The runtime fallback path itself (the case where level-0 scratch is genuinely exhausted) could not be exercised in this environment, as no GPU was available; the Serial backend testing covers correctness of both code paths but not the device-specific threshold.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system

**Further Information, Files, and Links**

- Upstream Kokkos enhancement referenced above: https://github.com/kokkos/kokkos/pull/9012


---
_Generated by [Claude Code](https://claude.ai/code/session_01L3e6KjkioUpVirFvVLi45x)_