### PR TITLE
KOKKOS: remove redundant fences in CommKokkos and CommTiledKokkos

### DIFF
--- a/src/KOKKOS/comm_kokkos.cpp
+++ b/src/KOKKOS/comm_kokkos.cpp
@@ -303,8 +303,14 @@ void CommKokkos::reverse_comm_device()
   for (int iswap = nswap-1; iswap >= 0; iswap--) {
     if (sendproc[iswap] != me) {
       if (comm_f_only && !atomKK->k_f.NEED_TRANSFORM) {
-        if (size_reverse_recv[iswap]) {
+
+        // one fence covers both MPI calls: no Kokkos work is launched between
+        // them, so a second fence would have nothing left to wait on
+
+        if ((size_reverse_recv[iswap]) || (size_reverse_send[iswap]))
           DeviceType().fence();
+
+        if (size_reverse_recv[iswap]) {
           MPI_Irecv(k_buf_recv.view<DeviceType>().data(),size_reverse_recv[iswap],MPI_DOUBLE,
                     sendproc[iswap],0,world,&request);
         }
@@ -312,7 +318,6 @@ void CommKokkos::reverse_comm_device()
           buf = (double *)atomKK->k_f.view<DeviceType>().data() +
             firstrecv[iswap]*atomKK->k_f.view<DeviceType>().extent(1);
 
-          DeviceType().fence();
           MPI_Send(buf,size_reverse_send[iswap],MPI_DOUBLE,
                    recvproc[iswap],0,world);
         }
@@ -417,13 +422,16 @@ void CommKokkos::forward_comm_device(Fix *fix, int size)
         buf_recv_fix = k_buf_recv_fix.view_host().data();
       }
 
-      if (recvnum[iswap]) {
+      // the buffer is packed before the MPI calls, so one fence covers both
+
+      if ((recvnum[iswap]) || (sendnum[iswap]))
         DeviceType().fence();
+
+      if (recvnum[iswap]) {
         MPI_Irecv(buf_recv_fix,nsize*recvnum[iswap],MPI_DOUBLE,
                   recvproc[iswap],0,world,&request);
       }
       if (sendnum[iswap]) {
-        DeviceType().fence();
         MPI_Send(buf_send_fix,n,MPI_DOUBLE,sendproc[iswap],0,world);
       }
 
@@ -509,13 +517,16 @@ void CommKokkos::reverse_comm_device(Fix *fix, int size)
         buf_recv_fix = k_buf_recv_fix.view_host().data();
       }
 
-      if (sendnum[iswap]) {
+      // the buffer is packed before the MPI calls, so one fence covers both
+
+      if ((sendnum[iswap]) || (recvnum[iswap]))
         DeviceType().fence();
+
+      if (sendnum[iswap]) {
         MPI_Irecv(buf_recv_fix,nsize*sendnum[iswap],MPI_DOUBLE,
                   sendproc[iswap],0,world,&request);
       }
       if (recvnum[iswap]) {
-        DeviceType().fence();
         MPI_Send(buf_send_fix,n,MPI_DOUBLE,recvproc[iswap],0,world);
       }
       if (sendnum[iswap]) {
@@ -614,13 +625,16 @@ void CommKokkos::forward_comm_device(Compute *compute, int size)
         buf_recv_compute = k_buf_recv_compute.view_host().data();
       }
 
-      if (recvnum[iswap]) {
+      // the buffer is packed before the MPI calls, so one fence covers both
+
+      if ((recvnum[iswap]) || (sendnum[iswap]))
         DeviceType().fence();
+
+      if (recvnum[iswap]) {
         MPI_Irecv(buf_recv_compute,nsize*recvnum[iswap],MPI_DOUBLE,
                   recvproc[iswap],0,world,&request);
       }
       if (sendnum[iswap]) {
-        DeviceType().fence();
         MPI_Send(buf_send_compute,n,MPI_DOUBLE,sendproc[iswap],0,world);
       }
 
@@ -753,13 +767,16 @@ void CommKokkos::forward_comm_device(Pair *pair, int size)
         buf_recv_pair = k_buf_recv_pair.view_host().data();
       }
 
-      if (recvnum[iswap]) {
+      // the buffer is packed before the MPI calls, so one fence covers both
+
+      if ((recvnum[iswap]) || (sendnum[iswap]))
         DeviceType().fence();
+
+      if (recvnum[iswap]) {
         MPI_Irecv(buf_recv_pair,nsize*recvnum[iswap],MPI_DOUBLE,
                   recvproc[iswap],0,world,&request);
       }
       if (sendnum[iswap]) {
-        DeviceType().fence();
         MPI_Send(buf_send_pair,n,MPI_DOUBLE,sendproc[iswap],0,world);
       }
 
@@ -863,12 +880,15 @@ void CommKokkos::reverse_comm_device(Pair *pair, int size)
     }
 
     if (sendproc[iswap] != me) {
-      if (sendnum[iswap]) {
+      // the buffer is packed before the MPI calls, so one fence covers both
+
+      if ((sendnum[iswap]) || (recvnum[iswap]))
         DeviceType().fence();
+
+      if (sendnum[iswap]) {
         MPI_Irecv(buf_recv_pair,nsize*sendnum[iswap],MPI_DOUBLE,sendproc[iswap],0,world,&request);
       }
       if (recvnum[iswap]) {
-        DeviceType().fence();
         MPI_Send(buf_send_pair,n,MPI_DOUBLE,recvproc[iswap],0,world);
       }
       if (sendnum[iswap]) {
@@ -1241,12 +1261,13 @@ void CommKokkos::exchange_device()
         }
         if (nrecv > maxrecv) grow_recv_kokkos(nrecv);
 
+        // the buffer is packed before the MPI calls, so one fence covers both
+
         DeviceType().fence();
         MPI_Irecv(k_buf_recv.view<DeviceType>().data(),nrecv1,
                   MPI_DOUBLE,procneigh[dim][1],0,
                   world,&request);
 
-        DeviceType().fence();
         MPI_Send(k_buf_send.view<DeviceType>().data(),nsend,
                  MPI_DOUBLE,procneigh[dim][0],0,world);
 
@@ -1311,12 +1332,13 @@ void CommKokkos::exchange_device()
 
             if (nextrarecv > maxrecv) grow_recv_kokkos(nextrarecv);
 
+            // the buffer is packed before the MPI calls, one fence covers both
+
             DeviceType().fence();
             MPI_Irecv(k_buf_recv.view<DeviceType>().data(),nextrarecv1,
                       MPI_DOUBLE,procneigh[dim][1],0,
                       world,&request);
 
-            DeviceType().fence();
             MPI_Send(k_buf_send.view<DeviceType>().data(),nextrasend,
                      MPI_DOUBLE,procneigh[dim][0],0,world);
 
@@ -1622,14 +1644,17 @@ void CommKokkos::borders_device() {
         MPI_Sendrecv(&nsend,1,MPI_INT,sendproc[iswap],0,
                      &nrecv,1,MPI_INT,recvproc[iswap],0,world,MPI_STATUS_IGNORE);
         if (nrecv*size_border > maxrecv) grow_recv_kokkos(nrecv*size_border);
+
+        // the buffer is packed before the MPI calls, so one fence covers both
+
+        if ((nrecv) || (n)) DeviceType().fence();
+
         if (nrecv) {
-          DeviceType().fence();
           MPI_Irecv(k_buf_recv.view<DeviceType>().data(),
                     nrecv*size_border,MPI_DOUBLE,
                     recvproc[iswap],0,world,&request);
         }
         if (n) {
-          DeviceType().fence();
           MPI_Send(k_buf_send.view<DeviceType>().data(),n,
                    MPI_DOUBLE,sendproc[iswap],0,world);
         }

--- a/src/KOKKOS/comm_tiled_kokkos.cpp
+++ b/src/KOKKOS/comm_tiled_kokkos.cpp
@@ -139,10 +139,13 @@ void CommTiledKokkos::forward_comm_device()
 
     if (comm_x_only && !atomKK->k_x.NEED_TRANSFORM) {
       if (recvother[iswap]) {
+
+        // no Kokkos work is launched inside the loop, so fence only once
+
+        DeviceType().fence();
         for (i = 0; i < nrecv; i++) {
           buf = (double*)atomKK->k_x.view<DeviceType>().data() +
             firstrecv[iswap][i]*atomKK->k_x.view<DeviceType>().extent(1);
-          DeviceType().fence();
           MPI_Irecv(buf,size_forward_recv[iswap][i],
                     MPI_DOUBLE,recvproc[iswap][i],0,world,&requests[i]);
         }
@@ -168,10 +171,13 @@ void CommTiledKokkos::forward_comm_device()
 
     } else if (ghost_velocity) {
       if (recvother[iswap]) {
+
+        // no Kokkos work is launched inside the loop, so fence only once
+
+        DeviceType().fence();
         for (i = 0; i < nrecv; i++) {
           buf = k_buf_recv.view<DeviceType>().data() +
             forward_recv_offset[iswap][i]*k_buf_recv.view<DeviceType>().extent(1);
-          DeviceType().fence();
           MPI_Irecv(buf,
                     size_forward_recv[iswap][i],MPI_DOUBLE,recvproc[iswap][i],0,world,&requests[i]);
         }
@@ -204,10 +210,13 @@ void CommTiledKokkos::forward_comm_device()
 
     } else {
       if (recvother[iswap]) {
+
+        // no Kokkos work is launched inside the loop, so fence only once
+
+        DeviceType().fence();
         for (i = 0; i < nrecv; i++) {
           buf = k_buf_recv.view<DeviceType>().data() +
             forward_recv_offset[iswap][i]*k_buf_recv.view<DeviceType>().extent(1);
-          DeviceType().fence();
           MPI_Irecv(buf,
                     size_forward_recv[iswap][i],MPI_DOUBLE,recvproc[iswap][i],0,world,&requests[i]);
         }
@@ -282,11 +291,17 @@ void CommTiledKokkos::reverse_comm_device()
     nrecv = nrecvproc[iswap] - sendself[iswap];
 
     if (comm_f_only  && !atomKK->k_f.NEED_TRANSFORM) {
+
+      // no Kokkos work is launched inside or between the two loops,
+      // so one fence covers both
+
+      if ((sendother[iswap]) || (recvother[iswap]))
+        DeviceType().fence();
+
       if (sendother[iswap]) {
         for (i = 0; i < nsend; i++) {
           buf = k_buf_recv.view<DeviceType>().data() +
             reverse_recv_offset[iswap][i]*k_buf_recv.view<DeviceType>().extent(1);
-          DeviceType().fence();
           MPI_Irecv(buf,
                     size_reverse_recv[iswap][i],MPI_DOUBLE,sendproc[iswap][i],0,world,&requests[i]);
         }
@@ -295,7 +310,6 @@ void CommTiledKokkos::reverse_comm_device()
         for (i = 0; i < nrecv; i++) {
           buf = (double*)atomKK->k_f.view<DeviceType>().data() +
             firstrecv[iswap][i]*atomKK->k_f.view<DeviceType>().extent(1);
-          DeviceType().fence();
           MPI_Send(buf,size_reverse_send[iswap][i],
                    MPI_DOUBLE,recvproc[iswap][i],0,world);
         }
@@ -318,10 +332,13 @@ void CommTiledKokkos::reverse_comm_device()
 
     } else {
       if (sendother[iswap]) {
+
+        // no Kokkos work is launched inside the loop, so fence only once
+
+        DeviceType().fence();
         for (i = 0; i < nsend; i++) {
           buf = k_buf_recv.view<DeviceType>().data() +
             reverse_recv_offset[iswap][i]*k_buf_recv.view<DeviceType>().extent(1);
-          DeviceType().fence();
           MPI_Irecv(buf,
                     size_reverse_recv[iswap][i],MPI_DOUBLE,sendproc[iswap][i],0,world,&requests[i]);
         }
@@ -475,6 +492,11 @@ void CommTiledKokkos::forward_comm_device(Pair *pair, int size)
     nrecv = nrecvproc[iswap] - sendself[iswap];
 
     if (recvother[iswap]) {
+
+      // fence before posting the receives: the unpack kernels of the previous
+      // swap may still be reading from the same receive buffer
+
+      DeviceType().fence();
       for (i = 0; i < nrecv; i++)
         MPI_Irecv(&buf_recv_pair[nsize*forward_recv_offset[iswap][i]],
                   nsize*recvnum[iswap][i],MPI_DOUBLE,recvproc[iswap][i],0,world,&requests[i]);
@@ -589,6 +611,11 @@ void CommTiledKokkos::reverse_comm_device(Pair *pair, int size)
     nrecv = nrecvproc[iswap] - sendself[iswap];
 
     if (sendother[iswap]) {
+
+      // fence before posting the receives: the unpack kernels of the previous
+      // swap may still be reading from the same receive buffer
+
+      DeviceType().fence();
       for (i = 0; i < nsend; i++)
         MPI_Irecv(&buf_recv_pair[nsize*reverse_recv_offset[iswap][i]],
                   nsize*sendnum[iswap][i],MPI_DOUBLE,sendproc[iswap][i],0,world,&requests[i]);


### PR DESCRIPTION
**Summary**

Removes redundant device fences in the GPU-aware MPI communication paths of `CommKokkos` and `CommTiledKokkos`, and adds two missing fences in the tiled Pair comm.

The fences around MPI calls are required with GPU-aware MPI: the Kokkos default execution space instance owns a private stream, so nothing else orders MPI's asynchronous device activity against Kokkos kernels. However, a number of fences sit where no Kokkos work can be in flight:

- In the Fix, Compute, and Pair comm routines, in `exchange()` and `borders()`, and in the `comm_f_only` reverse comm, the send buffer is packed *before* the `MPI_Irecv` is posted, so only a host-side `MPI_Irecv` separates the fence before the receive from the fence before the send. These are merged into a single fence taken under the union of the two original guards, so every path that fenced before still fences.
- In `CommTiledKokkos` the fences sat *inside* the loops posting receives, where the loop body only does pointer arithmetic and calls MPI — all but the first iteration fenced an idle stream. These are hoisted out of the loops. Loops whose body packs a buffer per iteration keep their per-iteration fence.
- The fences after `MPI_Wait` and the fences in the atom comm routines where a pack kernel runs between the receive and the send are all unchanged.

Also fixes a pre-existing race: `CommTiledKokkos::forward_comm_device(Pair*)` and `reverse_comm_device(Pair*)` posted `MPI_Irecv` into the receive buffer with no fence, while the previous swap's unpack kernels could still be reading it (and `grow_buf_pair()` could resize it). A fence is added before the receive loop in both, matching all the sibling comm paths.

Net effect: ~6-10% fewer fences per timestep in multi-rank GPU-aware runs (measured with a KokkosP profiling tool), with no change in which MPI calls are protected.

**Related Issue(s)**

Prompted by the analysis in kokkos/kokkos#9404, which claimed the fence after `MPI_Wait` and the fence before `MPI_Irecv` in `CommKokkos::forward_comm_device()` are redundant. Those specific fences are *not* redundant (they are the only synchronization between MPI's device-side activity and the Kokkos stream, and removing them corrupts results on CUDA and HIP); the redundancies fixed here are different ones found while evaluating that claim.

**Author(s)**

Stan Moore, Sandia National Laboratories (stamoor at sandia.gov)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Artificial Intelligence (AI) Tools Usage**

The code changes in this pull request were generated by Anthropic's Claude Code (Claude Opus), working under the direction and review of Stan Moore. The analysis of which fences are redundant, the verification tooling (a KokkosP/PMPI fence-order checker), and the commit message were also AI-generated. All changes were reviewed by a human before submission.

**Backward Compatibility**

No changes to inputs or user-visible behavior. No API changes.

**Implementation Notes**

Correctness rests on one invariant: a fence may be removed only if no Kokkos work (kernel launch, dual-view sync, deep_copy, buffer resize/grow) is enqueued between it and the previous fence covering the same MPI calls. Verification performed (CPU/Serial backend, OpenMPI):

- Static analysis of both files, before and after: every device-buffer MPI call has a preceding fence with no Kokkos work in between; the only two violations found in the *old* code are the two tiled Pair paths this PR adds fences to.
- Dynamic verification with a KokkosP profiling tool + PMPI interposer that flags any `MPI_DOUBLE` traffic issued while Kokkos work is unfenced: zero violations before and after, across brick/tiled comm, 1-8 MPI ranks, regular and irregular (RCB, `fix balance`) decompositions, lj/cut and eam/alloy + `fix spring/self` + `compute coord/atom` workloads, 250-2000 timesteps. Kernel counts and MPI call counts are identical before/after; only fence counts drop.
- Per-atom bitwise comparison (`x`, `v`, `f` at `%.17g`) between unpatched and patched binaries: identical in 17 of 18 configurations; the one difference (irregular RCB, 8 ranks, tiled) is pre-existing run-to-run nondeterminism from `MPI_Waitany` arrival-order force accumulation — the unpatched binary differs from itself by the same magnitude (~1e-14 in x).
- No new compiler warnings with `-Wall -Wextra`.

Caveat: fences are no-ops under the Serial backend, and the Fix/Compute/Pair device comm paths are unreachable on CPU-only builds, so the synchronization behavior itself still needs validation on GPU hardware with GPU-aware MPI (in progress). The most sensitive configuration is `comm_style tiled` with an irregular RCB decomposition at high rank count.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the CMake based build system

**Further Information, Files, and Links**

- kokkos/kokkos#9404 (multi-GPU communication performance report that prompted this audit)
- `Grid3dKokkos` already uses the single-fence-per-transfer structure this PR converges on, so the KOKKOS comm paths are now consistent across classes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EQr6U7N3Bs84rEo9tjXhSC)_